### PR TITLE
frontpage: Add information boxes, align styling with Zenodo

### DIFF
--- a/assets/less/zenodo-rdm/collections/menu.overrides
+++ b/assets/less/zenodo-rdm/collections/menu.overrides
@@ -1,0 +1,16 @@
+/*
+ *   Copyright (C) 2021-2022 CERN.
+ *
+ * Invenio App RDM is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+#invenio-nav.ui.menu {
+  .ui.menu {
+    .item {
+      a:not(.ui.button) {
+      padding: 2.8rem 1rem;
+      }
+    }
+  }
+}

--- a/assets/less/zenodo-rdm/collections/menu.variables
+++ b/assets/less/zenodo-rdm/collections/menu.variables
@@ -1,0 +1,6 @@
+/*
+ *   Copyright (C) 2021-2022 CERN.
+ *
+ * Invenio App RDM is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */

--- a/assets/less/zenodo-rdm/elements/button.overrides
+++ b/assets/less/zenodo-rdm/elements/button.overrides
@@ -1,0 +1,10 @@
+/*
+ *   Copyright (C) 2021-2022 CERN.
+ *
+ * Invenio App RDM is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+.ui.search.button {
+  border: 1px solid @borderColor;
+}

--- a/assets/less/zenodo-rdm/elements/button.variables
+++ b/assets/less/zenodo-rdm/elements/button.variables
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (C) 2021-2022 CERN.
+ *
+ * Invenio App RDM is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+// Default button
+@textColor: #333;
+@fontWeight: @normal;
+
+@backgroundColor: #fff;
+@borderBoxShadowColor: #adadad;
+@borderBoxShadowWidth: 1px;
+@borderBoxShadow: 0 0 0 @borderBoxShadowWidth @borderBoxShadowColor inset;;
+
+/* Hovered */
+@hoverBackgroundColor: #e6e6e6;
+
+/* Pressed Down */
+@downBackgroundColor: @hoverBackgroundColor;
+@downPressedShadow: inset 0 3px 5px rgba(0,0,0, .13);
+
+
+
+// Search button
+@searchButtonColor: #fff;
+@searchButtonColorTextColor: #333;
+
+
+
+// Signup button
+@signupColor: @warningColor;
+@signupColorTextColor: #fff;

--- a/assets/less/zenodo-rdm/elements/segment.overrides
+++ b/assets/less/zenodo-rdm/elements/segment.overrides
@@ -5,8 +5,18 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
- .ui.segment.rdm-sidebar {
-   
+.ui.segment.rdm-sidebar {
+  background-color: @rdmSidebarSegmentColor;
+  border: 1px solid @rdmSidebarSegmentBorderColor;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.05);
+  padding: @defaultPadding .75*@defaultPadding;
+
+  h2.ui.small.header {
+    font-size: @big;
+    border-bottom: 0;
+    font-weight: 500;
+  }
+
   &#record-manage-menu {
     padding: 0;
     margin: 0;

--- a/assets/less/zenodo-rdm/elements/segment.variables
+++ b/assets/less/zenodo-rdm/elements/segment.variables
@@ -1,0 +1,9 @@
+/*
+ *   Copyright (C) 2021-2022 CERN.
+ *
+ * Invenio App RDM is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+@rdmSidebarSegmentColor: #f5f5f5;
+@rdmSidebarSegmentBorderColor: #e3e3e3;

--- a/assets/less/zenodo-rdm/globals/site.overrides
+++ b/assets/less/zenodo-rdm/globals/site.overrides
@@ -5,21 +5,26 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-@navbarBackgroundImage: linear-gradient(to right,#0047A8 0,#2BBCFF 100%);
-@searchButtonColor: #f2711c;
+body {
+  font-weight: @normal;
 
-.navbar-search-bar button{
-    background-color: @searchButtonColor !important;
+  strong {
+    font-weight: @bold;
+  }
+}
+
+#invenio-nav {
+  min-height: 96px;
+}
+
+.logo {
+  width: 160px;
+  margin-right: 2rem;
 }
 
 .rdm-logo {
-    width: 150px !important;
-}
-
-.logo-link {
-    display: flex !important;
-    justify-content: center;
-    align-items: center;
+    width: 100%;
+    padding-bottom: .5rem;
 }
 
 /*Creatibutors modal*/

--- a/assets/less/zenodo-rdm/globals/site.variables
+++ b/assets/less/zenodo-rdm/globals/site.variables
@@ -4,3 +4,25 @@
  * Invenio App RDM is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
+
+// Colors
+@warningColor: #EB9419;
+@positiveColor: #3A833A;
+@negativeColor: #D33B36;
+
+// Navbar
+@navbarBackgroundImage: linear-gradient(to right,#0047A8 0,#2BBCFF 100%);
+
+
+// Footer colors
+@footerLightColor: #0067c9;
+@footerDarkColor: #0047a8;
+@footerTextLightColor: #c9e5ff;
+
+
+// Font weights
+@normal: 300;
+@semibold: 500;
+@bold: 700;
+
+@headerFontWeight: @semibold;

--- a/templates/semantic-ui/zenodo_rdm/footer.html
+++ b/templates/semantic-ui/zenodo_rdm/footer.html
@@ -25,7 +25,7 @@
 {%- extends "invenio_app_rdm/footer.html" %}
 
 {%- block footer_top_left %}
-<div class="ui equal width divided stackable grid">
+<div class="ui equal width stackable grid">
   <div class="column">
     <h4 class="ui inverted header">{{_('About')}}</h4>
     <div class="ui inverted link list">

--- a/templates/semantic-ui/zenodo_rdm/frontpage.html
+++ b/templates/semantic-ui/zenodo_rdm/frontpage.html
@@ -29,64 +29,65 @@
 {%- endblock page_header %}
 
 {%- block first_section%}
-<div class="invenio-rdm-project-section section-content white-bg">
-  <div class="ui container">
-    <h1 class="ui center aligned huge header">{{config.THEME_SITENAME}} in a nutshell</h1>
-    <div class="ui three column stackable padded grid">
-      <div class="left floated column">
-        <h3 class="ui center aligned icon header">
-          <i class="globe icon"></i>
-          Research. Shared.
-        </h3>
-        <div class="content">
-          All research outputs from across all fields of research are welcome! Sciences and Humanities, really!
-        </div>
-      </div>
-      <div class="column">
-        <h3 class="ui center aligned icon header">
-          <i class="search icon"></i>
-          Citeable. Discoverable.
-        </h3>
-        <div class="content">
-          Uploads gets a Digital Object Identifier (DOI) to make them easily and uniquely citeable.
-        </div>
-      </div>
-      <div class="right floated column">
-        <h3 class="ui center aligned icon header">
-          <i class="users icon"></i>
-          Communities
-        </h3>
-        <div class="content">
-          Create and curate your own community for a workshop, project, department, journal, into which you can accept or reject uploads. Your own complete digital repository!
-        </div>
-      </div>
-
-      <div class="left floated column">
-        <h3 class="ui center aligned icon header">
-          <i class="money icon"></i>
-          Funding
-        </h3>
-        <div class="content">
-          Identify grants, integrated in reporting lines for research funded by the European Commission via OpenAIRE.
-        </div>
-      </div>
-      <div class="column">
-        <h3 class="ui center aligned icon header">
-          <i class="lock open icon"></i>
-          Flexible licensing
-        </h3>
-        <div class="content">Because not everything is under Creative Commons.</div>
-      </div>
-      <div class="right floated column">
-        <h3 class="ui center aligned icon header">
-          <i class="shield icon"></i>
-          Safe
-        </h3>
-        <div class="content">
-          Your research output is stored safely for the future in the same cloud infrastructure as CERN's own LHC research data.
-        </div>
+<div class="ui container rel-mt-3">
+  <div class="ui stackable grid">
+    <div class="eleven wide computer sixteen wide tablet column">
+      <h2>{{ _("Recent uploads") }}</h2>
+      <div>
+        ...
       </div>
     </div>
+    <aside class="five wide computer sixteen wide tablet column">
+      <section class="ui segment rdm-sidebar">
+        <h2 class="ui small header">{{ _("Need help?") }} </h2>
+        <a href="/support" class="ui button fluid rel-mb-1">Contact us</a>
+        <p>
+          Zenodo prioritizes all requested related to the COVID-19 outbreak.
+
+          We can help with:
+
+            <ul>
+              <li>Uploading your research data, software, preprints, etc.</li>
+              <li>One-on-one with Zenodo supporters.</li>
+              <li>Quota increases beyond our default policy.</li>
+              <li>Scripts for automated uploading of larger datasets.</li>
+            </ul>
+        </p>
+      </section>
+
+      <section class="ui segment rdm-sidebar">
+        <h2 class="ui small header">{{ _("Why use Zenodo?") }} </h2>
+        <p>
+          <ul>
+            <li>
+              <strong>Safe</strong> — your research is stored safely for the future in CERN’s Data Centre for as long as CERN exists.
+            </li>
+            <li>
+              <strong>Trusted</strong> — built and operated by CERN and OpenAIRE to ensure that everyone can join in Open Science.
+            </li>
+            <li>
+              <strong>Citeable</strong> — every upload is assigned a Digital Object Identifier (DOI), to make them citable and trackable.
+            </li>
+            <li>
+              <strong>No waiting time</strong> — Uploads are made available online as soon as you hit publish, and your DOI is registered within seconds.
+            </li>
+            <li>
+              <strong>Open or closed</strong> — Share e.g. anonymized clinical trial data with only medical professionals via our restricted access mode.
+            </li>
+            <li>
+              <strong>Versioning</strong> — Easily update your dataset with our versioning feature.
+            </li>
+            <li>
+              <strong>GitHub integration</strong> — Easily preserve your GitHub repository in Zenodo.
+            </li>
+            <li>
+              <strong>Usage statistics</strong> — All uploads display standards compliant usage statistics
+            </li>
+          </ul>
+        </p>
+      </section>
+    </aside>
   </div>
 </div>
+
 {%- endblock first_section %}

--- a/templates/semantic-ui/zenodo_rdm/header_frontpage.html
+++ b/templates/semantic-ui/zenodo_rdm/header_frontpage.html
@@ -23,27 +23,9 @@
   -#}
   
 {%- extends "invenio_app_rdm/header_frontpage.html" %}
+{%- block navbar_search %}
+  {%- include "invenio_app_rdm/searchbar.html" %}
+{% endblock navbar_search %}
 
 {%- block frontpage_search %}
-<div class="ui container two column centered middle aligned grid">
-  <div class="sixteen wide mobile ten wide computer column">
-    <div class="row middle aligned">
-      <div class="sixteen wide column frontpage-search">
-        {# Don't display the website title #}
-        {%- block frontpage_title %}
-        <div class="ui divider hidden"></div>
-        {%- endblock frontpage_title %}
-        {%- block frontpage_form %}
-        <form action="/search" class="ui form" role="search">
-          <div class="ui fluid action input">
-            <input type="text" name="q" class="form-control" placeholder="{{ _("Search") }}">
-            <button type="submit" class="ui icon button orange" aria-label="Search"><i class="search icon"></i></button>
-          </div>
-        </form>
-        <div class="ui divider hidden"></div>
-        {%- endblock frontpage_form %}
-      </div>
-    </div>
-  </div>
-</div>
 {%- endblock frontpage_search %}


### PR DESCRIPTION
closes https://github.com/zenodo/zenodo-rdm/issues/42

- Adds correct color to default button, search button and signup button
- Adds correct height of the top header
- Removes vertical dividers in the footer
- Adds info-boxes to the front page => Styles sidebar boxes on landing page

*Note:* I decreased the brightness of the button colors slightly as they were not good enough for accessibility

## Screenshots 

### Zenodo-rdm
![Screenshot 2022-10-12 at 16 46 45](https://user-images.githubusercontent.com/21052053/195375111-3af2cefa-f3a9-4d62-bef7-b6e4b9a42c3d.png)
![Screenshot 2022-10-14 at 09 22 29](https://user-images.githubusercontent.com/21052053/195787237-e60145f3-0f87-4cc3-bfd2-1ef661a57f47.png)
![Screenshot 2022-10-14 at 09 22 35](https://user-images.githubusercontent.com/21052053/195787263-385f0c6b-b5d6-4986-b656-6175eb3a01e3.png)



### Zenodo.org

![Screenshot 2022-10-12 at 15 25 50](https://user-images.githubusercontent.com/21052053/195354914-078cfec7-ca0d-4494-9a9e-50e2be489c71.png)
![Screenshot 2022-10-12 at 15 25 56](https://user-images.githubusercontent.com/21052053/195354928-c908084b-de37-49e4-a5ba-a6c6d2a55bb6.png)


