### PR TITLE
communities frontpage: edit layout and styling

### DIFF
--- a/assets/less/zenodo-rdm/views/card.overrides
+++ b/assets/less/zenodo-rdm/views/card.overrides
@@ -1,0 +1,47 @@
+
+.community-frontpage-cards {
+  background-color: transparent;
+  padding: .5*@defaultPadding;
+  
+  a.ui.card {
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+    text-align: center;
+    border-radius: 0;
+
+    &:hover {
+      text-decoration: none;
+      box-shadow: none;
+      border: none;
+    }
+
+    &:not(:last-child){
+      @media screen and (min-width: @tabletBreakpoint) { 
+        border-right: 1px solid @borderColor;
+        padding-right: @defaultPadding;
+      }
+    }
+
+    .image {
+      max-height: @maxLogoHeight;
+      max-width: @maxLogoWidth;
+      margin: 0 auto;
+      border-radius: 0 !important;
+      border-bottom: none;
+
+      &.fallback_image,
+      &.placeholder {
+        img {
+          object-fit: contain;
+          opacity: .5;
+          border-radius: 100%;
+        }
+      }
+    }
+
+    .content {
+      border: none;
+    }
+  }
+}

--- a/assets/less/zenodo-rdm/views/card.variables
+++ b/assets/less/zenodo-rdm/views/card.variables
@@ -1,0 +1,3 @@
+
+@maxLogoHeight: 10rem;
+@maxLogoWidth: @maxLogoHeight;

--- a/templates/semantic-ui/invenio_communities/frontpage.html
+++ b/templates/semantic-ui/invenio_communities/frontpage.html
@@ -1,0 +1,92 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2016-2020 CERN.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% extends "invenio_communities/base.html" %}
+
+{%- block javascript %}
+  {{ super() }}
+  {{ webpack['invenio-communities-frontpage.js'] }}
+{%- endblock %}
+
+{%- block page_body %}
+  <div class="ui container fluid page-subheader-outer ml-0-mobile mr-0-mobile">
+    <div class="ui container centered grid page-subheader rel-pt-1">
+      <div class="one column row">
+        <div class="eight wide center aligned column mt-auto mb-auto">
+          <h1 class="ui header mr-10">{{ _('Communities') }}</h1>
+          <p class="text-muted">Created and curated by Zenodo users. 
+            {% if not current_user.is_authenticated %}
+              <a href="#community-info">Read more</a>
+            {% endif %}
+          </p>
+        </div>
+      </div>
+      <div class="two column stackable row">
+        <div class="eight wide tablet five wide computer column mt-auto mb-auto">
+          <form action="{{ url_for('invenio_communities.communities_search') }}" class="ui form">
+            <div class="ui fluid action input">
+              <input type="text" name="q" class="form-control" placeholder="{{ _('Search communities') }}">
+              <button type="submit" class="ui icon search button"><i class="search icon"></i></button>
+            </div>
+          </form>
+        </div>
+        <div class="three wide mobile five wide tablet three wide computer stretched column">
+          <a href="{{ config.COMMUNITIES_ROUTES['new'] }}" class="ui icon left labeled positive button" role="button">
+            <i class="icon plus"></i>
+            {{_('New community')}}
+          </a>
+        </div>
+      </div>
+      <div class="ui divider hidden"></div>
+    </div>
+  </div>
+  <!-- TODO: Add Featured communities slideshow here -->
+  <div class="ui container communities-frontpage rel-mt-3 rel-mb-2">
+    <div class="flex align-items-center">
+      <h2 class="ui header mb-0">{{ _('New communities') }}</h2>
+      <a class="rel-ml-1" href="{{url_for('invenio_communities.communities_search')}}">
+        {{ _('See all')}}
+      </a>
+    </div>
+    <div class="ui divider hidden"></div>
+    <div id="featured-communities" class="communities-list"></div>
+  </div>
+
+  <div class="ui divider"></div>
+  <div class="ui fluid container bg-gray">
+    <div class="ui container rel-pt-3">
+      <div class="ui stackable grid" id="community-info">
+        <!-- TODO: Add information about communities here -->
+        <!-- <div class="eight wide column">
+          <h2 class="ui medium header text-muted">What is a community?</h2>
+          <p class="text-muted">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sapien lacus, luctus vel ornare vitae, cursus ac libero. Interdum et malesuada fames ac ante ipsum primis in faucibus. 
+            <br><br>
+            Etiam eu lectus purus. Mauris sed diam ullamcorper, hendrerit est nec, finibus leo. Pellentesque bibendum elit sed nunc efficitur congue. Nullam ipsum lacus, aliquam quis tempus et, hendrerit eget ligula. Nam ipsum urna, luctus dapibus velit at, vestibulum auctor lacus.
+          </p>
+        </div> -->
+        <div class="eight wide column">
+          <h2 class="ui medium header text-muted">Want your own community?</h2>
+          <p class="text-muted">
+            It's easy. Just click the button to get started.
+          </p>
+          <a href="{{ config.COMMUNITIES_ROUTES['new'] }}" class="ui icon left labeled positive tiny button" role="button">
+            <i class="icon plus"></i>
+            {{_('New community')}}
+          </a>
+          <ul class="text-muted">
+            <li><strong>Curate</strong> — accept/reject what goes in your community collection.</li>
+            <li><strong>Export</strong> — your community collection is automatically exported via OAI-PMH</li>
+            <li><strong>Upload</strong> — get custom upload link to send to people</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+{%- endblock page_body %}


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/47

## Current state
- Commented out the "What is a communities" info section, as we don't have the content yet. To be added.
<img width="1535" alt="Screenshot 2022-10-17 at 13 45 53" src="https://user-images.githubusercontent.com/21052053/196174895-807188f7-cb0e-47a2-a666-6d0aa42b6f32.png">

<img width="1538" alt="Screenshot 2022-10-17 at 13 46 12" src="https://user-images.githubusercontent.com/21052053/196174887-735cb474-2acf-4b69-a086-9f55a81725a7.png">


## After featured communites is added
- When we have the featured communities slideshow, it should be added below the header like this:
![Zenodo-communities](https://user-images.githubusercontent.com/21052053/196175006-a21af19c-0ca3-4e2f-b9bf-0bccc450c59b.png)
