### PR TITLE
support: added error notifications to contact form

### DIFF
--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/FileUploader.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/FileUploader.js
@@ -20,7 +20,7 @@ const FileUploader = ({ dropzoneParams, maxFileSize, name, currentFiles, handleD
                     <div {...getRootProps()}>
                         <input {...inpProps} />
                         <label className="helptext mt-0">
-                            {`Optional. Max attachments size:`} {humanReadableBytes(maxFileSize, false)}
+                            {`Optional. Max attachments size: ${humanReadableBytes(maxFileSize, false)}`}
                         </label>
                         {currentFiles.length > 0
                             &&


### PR DESCRIPTION
closes https://github.com/zenodo/zenodo-rdm/issues/84

I am using semantic UI [Message](https://react.semantic-ui.com/collections/message) component. A list of strings is passed and they are rendered as an unnumbered list (e.g. one error string per each file that yielded an error).

Validation errors show a message "Form has validation errors. Please correct them and try again". Individual fields are highlighted using Formik by parsing the backend's validation error message.