### PR TITLE
assets: override metadata settings in the deposit form

### DIFF
--- a/assets/js/invenio_app_rdm/deposit/override.js
+++ b/assets/js/invenio_app_rdm/deposit/override.js
@@ -1,0 +1,4 @@
+export const overriddenComponents = {
+    "ReactInvenioDeposit.MetadataAccess.layout": () => null,
+    "ReactInvenioDeposit.MetadataOnlyToggle.layout": () => null,
+}


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/46

Overrides `<MetadataAccess />` and metadata-only toggle in `<FileUploaderToolbar />` in the deposit form.

**Needs**
- https://github.com/inveniosoftware/react-invenio-deposit/pull/602
- https://github.com/inveniosoftware/invenio-app-rdm/pull/1970

## Screenshot
<img width="1277" alt="Screenshot 2022-11-15 at 15 08 03" src="https://user-images.githubusercontent.com/21052053/201939953-9ebc07ab-0b20-4ae9-b6cc-0960fb8851e0.png">
