### PR TITLE
sidebar segment: correct placeholder bg color

### DIFF
--- a/assets/less/zenodo-rdm/elements/segment.overrides
+++ b/assets/less/zenodo-rdm/elements/segment.overrides
@@ -8,8 +8,8 @@
 .ui.segment.rdm-sidebar {
   background-color: @rdmSidebarSegmentColor;
   border: 1px solid @rdmSidebarSegmentBorderColor;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.05);
-  padding: @defaultPadding .75*@defaultPadding;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  padding: @defaultPadding 0.75 * @defaultPadding;
 
   h2.ui.small.header {
     font-size: @big;
@@ -28,16 +28,24 @@
       padding: 0;
     }
   }
+
+  .ui.placeholder {
+    &,
+    & .line,
+    & > :before {
+      background-color: @rdmSidebarSegmentColor;
+    }
+  }
 }
 
 .ui.segments.very.rounded {
-  border-radius: .8rem;
+  border-radius: 0.8rem;
 
   &:not(.horizontal) > .segment:first-child {
-    border-radius: .8rem .8rem 0 0;
+    border-radius: 0.8rem 0.8rem 0 0;
   }
 
   &:not(.horizontal) > .segment:last-child {
-    border-radius: 0 0 .8rem .8rem;
+    border-radius: 0 0 0.8rem 0.8rem;
   }
 }


### PR DESCRIPTION
The placeholder background color is currently white, which does not look great on the gray bg for the sidebar segments in Zenodo. 

This PR aligns the bg color of the placeholder with the sidebar segment.

## Screenshot
![Screenshot 2022-12-01 at 10 31 59](https://user-images.githubusercontent.com/21052053/205017538-dc5155f3-7e95-4049-b560-575f8c9ff82c.png)
