### PR TITLE
frontpage: add banner for sandbox info

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/frontpage.html
+++ b/templates/semantic-ui/zenodo_rdm/frontpage.html
@@ -28,6 +28,17 @@
   {%- include "zenodo_rdm/header_frontpage.html" %}
 {%- endblock page_header %}
 
+{% block page_body %}
+<div class="ui info flashed top attached manage message">
+  <div class="ui container">
+    This is future Zenodo's sandbox instance for testing purposes. See the
+    <a href="https://blog.zenodo.org/"><b>Zenodo Blog</b></a> for more details.
+  </div>
+</div>
+
+{{ super() }}
+{% endblock page_body %}
+
 {% block side_column_content %}
   <section class="ui segment rdm-sidebar">
     <h2 class="ui small header">{{ _("Need help?") }} </h2>


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/120

## Screenshot
<img width="1324" alt="Screenshot 2022-12-01 at 17 13 28" src="https://user-images.githubusercontent.com/21052053/205104031-15479dfa-91e4-41cb-85cc-056fecc57d7c.png">
