### PR TITLE
search: fixed resource subtype term mapping

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -133,7 +133,7 @@ OAISERVER_ID_PREFIX = "zenodo-rdm.web.cern.ch"
 SEARCH_INDEX_PREFIX = "zenodo-"
 
 ZENODO_LEGACY_SEARCH_MAP = {
-    "resource_type.test_subtype": "metadata.resource_type.props.subtype",
+    "resource_type.subtype": "metadata.resource_type.props.subtype",
     "resource_type.type": "metadata.resource_type.props.type",
     "access_right": "access.status",
     "alternate.identifier": "metadata.identifiers.identifier",


### PR DESCRIPTION
The term `resource_type.subtype` was wrongly mapped.