### PR TITLE
custom fields: added 'publishing information' fields under one section

### DIFF
--- a/site/zenodo_rdm/custom_fields.py
+++ b/site/zenodo_rdm/custom_fields.py
@@ -6,7 +6,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Custom fields."""
-
+from invenio_i18n import lazy_gettext as _
 from invenio_rdm_records.contrib.imprint import (
     IMPRINT_CUSTOM_FIELDS,
     IMPRINT_CUSTOM_FIELDS_UI,
@@ -147,19 +147,23 @@ CUSTOM_FIELDS = [
     *THESIS_CUSTOM_FIELDS,
 ]
 
+# hide meeting section
+MEETING_CUSTOM_FIELDS_UI["hidden"] = True
+
 # Custom fields UI components
 CUSTOM_FIELDS_UI = [
-{
+    {
         "section": _("Publishing information"),
+        "hidden": True,
         "fields": [
             # journal
             *JOURNAL_CUSTOM_FIELDS_UI["fields"],
             # imprint
             *IMPRINT_CUSTOM_FIELDS_UI["fields"],
             # thesis
-            *THESIS_CUSTOM_FIELDS_UI["fields"],   
-        ]
+            *THESIS_CUSTOM_FIELDS_UI["fields"],
+        ],
     },
     # meeting
-    MEETING_CUSTOM_FIELDS_UI
+    MEETING_CUSTOM_FIELDS_UI,
 ]

--- a/site/zenodo_rdm/custom_fields.py
+++ b/site/zenodo_rdm/custom_fields.py
@@ -149,8 +149,17 @@ CUSTOM_FIELDS = [
 
 # Custom fields UI components
 CUSTOM_FIELDS_UI = [
-    JOURNAL_CUSTOM_FIELDS_UI,
-    MEETING_CUSTOM_FIELDS_UI,
-    IMPRINT_CUSTOM_FIELDS_UI,
-    THESIS_CUSTOM_FIELDS_UI,
+{
+        "section": _("Publishing information"),
+        "fields": [
+            # journal
+            *JOURNAL_CUSTOM_FIELDS_UI["fields"],
+            # imprint
+            *IMPRINT_CUSTOM_FIELDS_UI["fields"],
+            # thesis
+            *THESIS_CUSTOM_FIELDS_UI["fields"],   
+        ]
+    },
+    # meeting
+    MEETING_CUSTOM_FIELDS_UI
 ]


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1232


Note: this must be spread in two places:

1 - upgrade documentation (e.g. "if you want to have the publishing custom fields grouped together ..."
2 - a place where other instances can have this out of the box (perhaps cookiecutter ?)