### PR TITLE
config: add sorting for conference, journal, versions and publication…

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -16,6 +16,9 @@ from invenio_i18n import lazy_gettext as _
 from invenio_oauthclient.contrib.openaire_aai import REMOTE_SANDBOX_APP
 from invenio_oauthclient.contrib.orcid import ORCIDOAuthSettingsHelper
 from invenio_oauthclient.contrib import github
+from invenio_rdm_records.config import RDM_SORT_OPTIONS as BASE_SORT_OPTIONS
+from invenio_rdm_records.contrib.journal import JOURNAL_SORT_OPTIONS
+from invenio_rdm_records.contrib.meeting import MEETING_SORT_OPTIONS
 from invenio_records_resources.services.records.queryparser import (
     QueryParser,
     SearchFieldTransformer,
@@ -23,7 +26,6 @@ from invenio_records_resources.services.records.queryparser import (
 from invenio_oauthclient.views.client import auto_redirect_login
 
 from zenodo_rdm.custom_fields import CUSTOM_FIELDS_UI, CUSTOM_FIELDS, NAMESPACES
-
 
 
 # Flask
@@ -194,9 +196,34 @@ ZENODO_LEGACY_SEARCH_MAP = {
     "thesis.university": "custom_fields.thesis\:university"
 }
 
+RDM_SORT_OPTIONS = {
+    # base brings bestmatch, newest, oldest, updated-desc, updated-asc, versions
+    # FIXME: there is no conceptrecid for versions, use parent id?
+    **BASE_SORT_OPTIONS,
+    "publication-desc": {
+        "title": _("Published [Newest]"),
+        "fields": ["-metadata.publication_date"],
+    },
+    "publication-asc": {
+        "title": ("Published [Oldest]"),
+        "fields": ["metadata.publication_date"],
+    },
+    **MEETING_SORT_OPTIONS,  # conference asc and desc
+    **JOURNAL_SORT_OPTIONS,  # journal asc and desc
+}
+
 RDM_SEARCH = {
     "facets": ["access_status", "resource_type", "subject"],
-    "sort": ["bestmatch", "newest", "oldest", "version"],
+    "sort": [
+        "bestmatch",
+        "newest",
+        "oldest",
+        "version",
+        "publication-desc",
+        "publication-asc",
+        "conference-desc",
+        "journal-desc",
+    ],
     "query_parser_cls": QueryParser.factory(
         tree_transformer_factory=SearchFieldTransformer.factory(
             mapping=ZENODO_LEGACY_SEARCH_MAP


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2030

**CURRENT STATUS**
![Screenshot 2023-03-24 at 14 49 02](https://user-images.githubusercontent.com/6756943/227540299-e84476b5-63ba-4459-bed8-1700c675716b.png)

**IDEAL**

We can treat it as a separate issue since it is purely UX/UI, extending the sort widget width to 16em (instead of 14) would fix it.
![Screenshot 2023-03-24 at 14 51 21](https://user-images.githubusercontent.com/6756943/227540294-763c74ae-ee60-4582-afa0-c73b29ddbd6e.png)

**Open questions**
- "Newest" / "Oldest" does not really make sense in this cases since they are sorting over numbers/strings. Should the be "Descending" or "Desc"?
- Do we want to test with icons? (this would require changes in other repositories/sortings too)
