### PR TITLE
config: Update OAI-PMH adminEmail

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -133,6 +133,7 @@ DATACITE_ENABLED = True
 DATACITE_PREFIX = "10.5281"
 DATACITE_TEST_MODE = True
 OAISERVER_ID_PREFIX = "zenodo-rdm.web.cern.ch"
+OAISERVER_ADMIN_EMAILS = ["info@zenodo.org"]
 
 # Invenio-Search
 # ==============


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/210

This PR adds the correct `adminEmail` to `OAISERVER_ADMIN_EMAILS` for Zenodo.

![Screenshot 2023-03-20 at 10 42 48](https://user-images.githubusercontent.com/21052053/226302403-518da774-26c0-4aad-8643-5cd6ca15a700.png)
