### PR TITLE
footer: update InvenioRDM link

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/footer.html
+++ b/templates/semantic-ui/zenodo_rdm/footer.html
@@ -87,7 +87,8 @@
   <div class="ui inverted container">
     <div class="ui grid">
       <div class="eight wide column left middle aligned">
-        Powered by <a href="http://information-technology.web.cern.ch/about/computer-centre">CERN Data Centre</a> & <a href="{{invenio_rdm}}">InvenioRDM</a>
+        Powered by 
+        <a href="http://information-technology.web.cern.ch/about/computer-centre">CERN Data Centre</a> & <a href="https://inveniordm.docs.cern.ch/">InvenioRDM</a>
       </div>
       <div class="eight wide column right aligned">
         <div class="ui inverted horizontal link list">


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/209

This PR adds the missing link in the footer.

(The previous variable in `href` was from a translation string in `invenio-app-rdm`)