### PR TITLE
config: remove metadata-only cmp overrides, add config variable instead

### DIFF
--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -1,4 +1,1 @@
-export const overriddenComponents = {
-    "ReactInvenioDeposit.MetadataAccess.layout": () => null,
-    "ReactInvenioDeposit.MetadataOnlyToggle.layout": () => null,
-}
+export const overriddenComponents = {}

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -134,6 +134,7 @@ DATACITE_PREFIX = "10.5281"
 DATACITE_TEST_MODE = True
 OAISERVER_ID_PREFIX = "zenodo-rdm.web.cern.ch"
 OAISERVER_ADMIN_EMAILS = ["info@zenodo.org"]
+RDM_ALLOW_METADATA_ONLY_RECORDS = False
 
 # Invenio-Search
 # ==============


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/200

This PR removes the overridden `MetadataOnly` components in `mappings.js` and adds the new config variable `RDM_ALLOW_METADATA_ONLY_RECORDS = False` instead.