### PR TITLE
support form: update send-request button text

### DIFF
--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/SupportForm.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/SupportForm.js
@@ -235,7 +235,7 @@ class SupportForm extends Component {
 
               <Modal.Actions className="label-padding">
                 <Button type="submit" positive>
-                  Send Request
+                  Send request
                 </Button>
               </Modal.Actions>
             </SemanticForm>


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/208

Updates button text in `<SupportForm/>` from "Send Request" to "Send request".