### PR TITLE
email templates: update markup and styling

### DIFF
--- a/templates/security/email/change_notice.html
+++ b/templates/security/email/change_notice.html
@@ -1,17 +1,21 @@
-<table style="padding:15px;background-color:#EAECEE;max-width:500px;margin:auto;">
-    <tbody style="text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
+<table style="max-width:500px;border-collapse:collapse;margin:auto;">
+    <tbody style="background-color:#EAECEE;text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
         <tr>
-            <td>
+            <td style="padding:15px 15px 10px 15px;">
                 <a href="{{ url_for('security.login', _external=True) }}">
                     <img src="{{ url_for('static', filename='images/zenodo-gradient-1000.png', _external=True) }}" style="width:250px;border-radius:10px;"/>
                 </a>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding:5px 15px 10px 15px;">
                 <p>{{ _('Hello, %(username)s!', username=user.username) }}</p>
                 <p>{{ _('Your password has been successfully changed!') }}</p>
             </td>
         </tr>
         {% if security.recoverable %}
         <tr>
-            <td>
+            <td style="padding:5px 15px 15px 15px;text-align:center;">
                 <p>{{ _('If you did not change your password, press the button below to reset it.') }}</p>
                 <p>
                     <a href="{{ url_for_security('forgot_password', _external=True) }}" style="display:inline-block;border-radius:5px;background-color:#3498DB;border:none;font-size:15px;text-decoration:none;color:white;padding:10px 24px;">

--- a/templates/security/email/confirmation_instructions.html
+++ b/templates/security/email/confirmation_instructions.html
@@ -1,18 +1,24 @@
-<table style="padding:15px;background-color:#EAECEE;max-width:500px;margin:auto;">
-    <tbody style="text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
+<table style="max-width:500px;border-collapse:collapse;margin:auto;">
+    <tbody style="background-color:#EAECEE;text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
         <tr>
-            <td>
+            <td style="padding:15px 15px 10px 15px;">
                 <a href="{{ url_for('security.login', _external=True) }}">
                     <img src="{{ url_for('static', filename='images/zenodo-gradient-1000.png', _external=True) }}" style="width:250px;border-radius:10px;"/>
-                </a>
+                </a>               
+            </td>
+        </tr>
+        <tr>
+            <td style="padding:5px 15px 10px 15px;">
                 <p>{{ _('Hello, %(username)s!', username=user.username) }}</p>
                 <p>{{ _('You have received this message because your email address has been registered with Zenodo.') }} </p>
                 <p>{{ _('Verify yourself and confirm your email by clicking below.') }}</p>
-                <p>
-                    <a class="btn confirm_button" href="{{ confirmation_link }}">
-                        {{ _('Confirm my account') }}
-                    </a>
-                </p>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding:5px 15px 15px 15px;text-align:center;">
+                <a class="btn confirm_button" href="{{ confirmation_link }}">
+                    {{ _('Confirm my account') }}
+                </a>
             </td>
         </tr>
     </tbody>

--- a/templates/security/email/reset_instructions.html
+++ b/templates/security/email/reset_instructions.html
@@ -1,19 +1,25 @@
-<table style="padding:15px;background-color:#EAECEE;max-width:500px;margin:auto;">
-    <tbody style="text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
+<table style="max-width:500px;border-collapse:collapse;margin:auto;">
+    <tbody style="background-color:#EAECEE;text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
         <tr>
-            <td>
+            <td style="padding:15px 15px 10px 15px;">
                 <a href="{{ url_for('security.login', _external=True) }}">
                     <img src="{{ url_for('static', filename='images/zenodo-gradient-1000.png', _external=True) }}" style="width:250px;border-radius:10px;"/>
                 </a>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding:5px 15px 10px 15px;">
                 <p>{{ _('Hello, %(username)s!', username=user.username) }}</p>
                 <p>{{ _('There was a request to reset your password.') }}</p>
                 <p>{{ _('If you did not make this request then please ignore this message.') }}</p>
                 <p>{{ _('Otherwise, please press the button below to change your password.') }}</p>
-                <p>
-                    <a href="{{ reset_link }}" style="display:inline-block;border-radius:5px;background-color:#3498DB;border:none;font-size:15px;text-decoration:none;color:white;padding:10px 24px;">
-                        {{ _('Reset my password') }}
-                    </a>
-                </p>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding:5px 15px 15px 15px;text-align:center;">
+                <a href="{{ reset_link }}" style="display:inline-block;border-radius:5px;background-color:#3498DB;border:none;font-size:15px;text-decoration:none;color:white;padding:10px 24px;">
+                    {{ _('Reset my password') }}
+                </a>
             </td>
         </tr>
     </tbody>

--- a/templates/security/email/reset_notice.html
+++ b/templates/security/email/reset_notice.html
@@ -1,17 +1,23 @@
-<table style="padding:15px;background-color:#EAECEE;max-width:500px;margin:auto;">
-    <tbody style="text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
+<table style="max-width:500px;border-collapse:collapse;margin:auto;">
+    <tbody style="background-color:#EAECEE;text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
         <tr>
-            <td>
+            <td style="padding:15px 15px 10px 15px;">
                 <a href="{{ url_for('security.login', _external=True) }}">
                     <img src="{{ url_for('static', filename='images/zenodo-gradient-1000.png', _external=True) }}" style="width:250px;border-radius:10px;"/>
                 </a>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding:5px 15px 10px 15px;">
                 <p>{{ _('Hello, %(username)s!', username=user.username) }}</p>
                 <p>{{ _('Your password has been successfully reset!') }}</p>
-                <p>
-                    <a href="{{ url_for('security.login', _external=True) }}" style="display:inline-block;border-radius:5px;background-color:#3498DB;border:none;font-size:15px;text-decoration:none;color:white;padding:10px 24px;">
-                        {{ _('Go to my account') }}
-                    </a>
-                </p>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding:5px 15px 15px 15px;text-align:center;">
+                <a href="{{ url_for('security.login', _external=True) }}" style="display:inline-block;border-radius:5px;background-color:#3498DB;border:none;font-size:15px;text-decoration:none;color:white;padding:10px 24px;">
+                    {{ _('Go to my account') }}
+                </a>
             </td>
         </tr>
     </tbody>

--- a/templates/security/email/welcome.html
+++ b/templates/security/email/welcome.html
@@ -1,10 +1,14 @@
-<table style="padding:15px;background-color:#EAECEE;max-width:500px;margin:auto;">
-    <tbody style="text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
+<table style="max-width:500px;border-collapse:collapse;margin:auto;">
+    <tbody style="background-color:#EAECEE;text-align:center;font-family:'Lato',Helvetica,Arial,sans-serif;">
         <tr>
-            <td>
+            <td style="padding:15px 15px 10px 15px;">
                 <a href="{{ url_for('security.login', _external=True) }}">
                     <img src="{{ url_for('static', filename='images/zenodo-gradient-1000.png', _external=True) }}" style="width:250px;border-radius:10px;"/>
                 </a>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding:5px 15px 10px 15px;">
                 <p>{{ _('Welcome %(username)s!', username=user.username) }}</p>
                 <p>{{ _('Your Zenodo account has been created.')}} </p>
                 <p>{{_('We are excited to have you get started!') }} </p>
@@ -13,7 +17,7 @@
 
         {% if security.confirmable %}
             <tr>
-                <td>
+                <td style="padding:5px 15px 15px 15px;text-align:center;">
                     <p>{{ _('First, you need to confirm your account. Just press the button below.') }}</p>
                     <p>
                         <a href="{{ confirmation_link }}" style="display:inline-block;border-radius:5px;background-color:#3498DB;border:none;font-size:15px;text-decoration:none;color:white;padding:10px 24px;">


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/214

I was not able to reproduce the error, as it occurs in iOS Mail, but I've been addressing some warnings about the markup/css in [MailTrap](https://mailtrap.io/):
- Padding only allowed on table cells
- Background-color and margin on the same element

I'm suspecting that the content overlap shown in the issue description could be because of the table markup (+ non-working css-spacing), so I moved each content-block to their own row/cell. 

Hopefully this fixes the issue.

