### PR TITLE
migrator: disable versioning on records stream

### DIFF
--- a/site/zenodo_rdm/migrator/streams.yaml
+++ b/site/zenodo_rdm/migrator/streams.yaml
@@ -12,6 +12,8 @@ communities:
 records:
   extract:
     filepath: /path/to/records.jsonl
+  load:
+    versioning: false
 drafts:
   extract:
     filepath: /path/to/deposits.jsonl


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-rdm-migrator/issues/75
- requires https://github.com/inveniosoftware/invenio-rdm-migrator/pull/78