### PR TITLE
migrator: re-use existing data loading for zenodo files

### DIFF
--- a/site/zenodo_rdm/migrator/load.py
+++ b/site/zenodo_rdm/migrator/load.py
@@ -36,21 +36,15 @@ class ZenodoFilesTableGenerator(TableGenerator):
 class ZenodoFilesLoad(PostgreSQLCopyLoad):
     """Zenodo to RDM Files class for data loading."""
 
-    def __init__(self, db_uri, tmp_dir, **kwargs):
+    def __init__(self, db_uri, data_dir, **kwargs):
         """Constructor."""
         super().__init__(
             db_uri=db_uri,
             table_generators=[ZenodoFilesTableGenerator()],
-            tmp_dir=tmp_dir,
+            data_dir=data_dir,
+            existing_data=True,
         )
-        # override default as we don't generate the table files again
-        self.tmp_dir = Path(tmp_dir)
 
     def _validate(self):
         """Validate data before loading."""
         return True
-
-    def _prepare(self, entries):
-        """Dump entries in csv files for COPY command."""
-        files_table_generator = self.table_generators[0]
-        return iter(files_table_generator.tables)

--- a/site/zenodo_rdm/migrator/streams.yaml
+++ b/site/zenodo_rdm/migrator/streams.yaml
@@ -1,3 +1,4 @@
+data_dir: /path/to/data
 tmp_dir: /path/to/tmp
 cache_dir: /path/to/cache
 log_dir: /path/to/log


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/invenio-rdm-migrator/pull/80
- closes https://github.com/inveniosoftware/invenio-rdm-migrator/issues/79

cleans up the files class, It could potentially be moved to rdm-migrator. But for now just clean up. 

Sample `streams.yaml` to do a run with exising data e.g. for all except last two streams (remember to move previous run csv files to `/tmp`):

```yaml
data_dir: /data
tmp_dir: /tmp
cache_dir: /cache
log_dir: /log
db_uri: postgresql://zenodo:zenodo@localhost:5432/zenodo
users:
  existing_data: true
  extract:
    filepath: /users.jsonl
files:
  existing_data: true
communities:
  existing_data: true
  extract:
    filepath: /communities.jsonl
records:
  existing_data: true
  extract:
    filepath: /records.jsonl
drafts:
  extract:
    filepath: /deposits.jsonl
requests:
  extract:
    filepath: /requests.jsonl
```