### PR TITLE
requests: add ui for upgrade legacy record request

### DIFF
--- a/assets/js/components/landing_page/overrides/UpgradeLegacyRecordButton.js
+++ b/assets/js/components/landing_page/overrides/UpgradeLegacyRecordButton.js
@@ -1,0 +1,98 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2023 CERN.
+//
+// Zenodo RDM is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { Component } from "react";
+import { Button, Grid, Message, Icon } from "semantic-ui-react";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+import { NewVersionButton } from "@js/invenio_rdm_records/";
+import PropTypes from "prop-types";
+import { http, withCancel } from "react-invenio-forms";
+
+export class UpgradeLegacyRecordButton extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      legacyRequestId: "",
+      fetchRequestsError: undefined,
+    };
+  }
+
+  componentDidMount() {
+    const { record, currentUserId } = this.props;
+    if (record.parent.access.owned_by[0].user == currentUserId) {
+      this.fetchRequests();
+    }
+  }
+
+  fetchRequests = async () => {
+    const { record } = this.props;
+    try {
+      const cancellableFetch = withCancel(
+        http.get(
+          `${record.links.requests}?q=type:legacy-record-upgrade&is_open=true`,
+          {
+            headers: {
+              Accept: "application/json",
+            },
+          }
+        )
+      );
+
+      const response = await cancellableFetch.promise;
+      const result = response.data.hits;
+      if (result.total > 0) {
+        this.setState({ legacyRequestId: result.hits[0].id });
+      }
+    } catch (error) {
+      let errorMessage = error.message;
+      if (error.response) {
+        errorMessage = error.response.data.message;
+      }
+
+      console.error(error);
+      this.setState({ fetchRequestsError: errorMessage });
+    }
+  };
+
+  render() {
+    const { isPreviewSubmissionRequest } = this.props;
+    const { legacyRequestId, fetchRequestsError } = this.state;
+    return (
+      <>
+        {legacyRequestId && !isPreviewSubmissionRequest && (
+          <Grid.Column className="pt-0">
+            <Button
+              fluid
+              color="white"
+              size="medium"
+              onClick={() =>
+                (window.location = `/me/requests/${legacyRequestId}`)
+              }
+              icon
+              labelPosition="left"
+            >
+              <Icon name="settings" />
+              {i18next.t("Upgrade legacy record")}
+            </Button>
+          </Grid.Column>
+        )}
+        {fetchRequestsError && (
+          <Grid.Row className="record-management">
+            <Grid.Column>
+              <Message negative>{fetchRequestsError}</Message>
+            </Grid.Column>
+          </Grid.Row>
+        )}
+      </>
+    );
+  }
+}
+
+UpgradeLegacyRecordButton.propTypes = {
+  isPreviewSubmissionRequest: PropTypes.bool.isRequired,
+  record: PropTypes.object.isRequired,
+  currentUserId: PropTypes.string.isRequired,
+};

--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -1,1 +1,11 @@
-export const overriddenComponents = {}
+// This file is part of InvenioRDM
+// Copyright (C) 2023 CERN.
+//
+// Zenodo RDM is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { UpgradeLegacyRecordButton } from "../../components/landing_page/overrides/UpgradeLegacyRecordButton";
+
+export const overriddenComponents = {
+  "InvenioAppRdm.RecordLandingPage.RecordManagement.container": UpgradeLegacyRecordButton,
+};

--- a/templates/semantic-ui/invenio_requests/legacy-record-upgrade/index.html
+++ b/templates/semantic-ui/invenio_requests/legacy-record-upgrade/index.html
@@ -1,0 +1,30 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Zenodo.
+  Copyright (C) 2023 CERN.
+
+  Zenodo is free software; you can redistribute it
+  and/or modify it under the terms of the GNU General Public License as
+  published by the Free Software Foundation; either version 2 of the
+  License, or (at your option) any later version.
+
+  Zenodo is distributed in the hope that it will be
+  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Zenodo; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+  MA 02111-1307, USA.
+
+  In applying this license, CERN does not
+  waive the privileges and immunities granted to it by virtue of its status
+  as an Intergovernmental Organization or submit itself to any jurisdiction.
+#}
+
+{#
+  Renders the request details page when upgrading a legacy record.
+#}
+
+{% extends "invenio_requests/community-submission/index.html" %}


### PR DESCRIPTION
* override record management component to include upgrade legacy record button
* use community-submission request jinja template for upgrade legacy record request
* closes https://github.com/zenodo/zenodo-rdm/issues/333


Upgrade legacy record button on landing page:
![Screenshot 2023-05-23 at 18 19 50](https://github.com/zenodo/zenodo-rdm/assets/61321254/b436e3e6-8403-477e-a092-b4beae3f6ca9)

Request in requests list:
![Screenshot 2023-05-23 at 15 56 32](https://github.com/zenodo/zenodo-rdm/assets/61321254/dd5a09ca-81ae-45b7-953d-134f249a00fb)

Submitted request:
![Screenshot 2023-05-23 at 15 57 45](https://github.com/zenodo/zenodo-rdm/assets/61321254/6186f428-0e45-4696-ab64-d39f292bff72)

Record tab in open request:
![Screenshot 2023-05-23 at 16 02 01](https://github.com/zenodo/zenodo-rdm/assets/61321254/74aca34c-c1a2-4113-9eae-58c4e951bde4)

Accepted request:
![Screenshot 2023-05-23 at 15 59 46](https://github.com/zenodo/zenodo-rdm/assets/61321254/17b429d0-125d-47dd-84d4-ce53b0bdefa1)

Declined request:
![Screenshot 2023-05-23 at 16 10 43](https://github.com/zenodo/zenodo-rdm/assets/61321254/7b91bd96-10d3-4fad-982d-69a0a0b3aea3)

Declined with a comment:
![Screenshot 2023-05-25 at 15 17 52](https://github.com/zenodo/zenodo-rdm/assets/61321254/00520767-f2c2-47e8-9c19-cec48d5647c0)

Declined with another comment:
![Screenshot 2023-05-25 at 15 15 37](https://github.com/zenodo/zenodo-rdm/assets/61321254/93774d19-6328-4f8d-bfd4-d4ddcb02c269)

Expired:
![Screenshot 2023-05-23 at 17 31 50](https://github.com/zenodo/zenodo-rdm/assets/61321254/fec17b39-f8a1-4256-bce9-5a8538541cb6)

Error handling (also in case if 2 errors occur):
![error](https://github.com/zenodo/zenodo-rdm/assets/61321254/e5e017a7-b260-4f53-9b68-22776458bd2e)
