### PR TITLE
Removing obsolete redirection

### DIFF
--- a/site/zenodo_rdm/config.py
+++ b/site/zenodo_rdm/config.py
@@ -221,10 +221,6 @@ REDIRECTOR_RULES = {
         "source": "/communities/<community_id>/curate",
         "target": communities_requests_view_function,
     },
-    "redirect_communities_about": {
-        "source": "/communities/<community_id>/about",
-        "target": communities_detail_view_function,
-    },
     "redirect_communities_edt": {
         "source": "/communities/<community_id>/edit",
         "target": communities_settings_view_function,


### PR DESCRIPTION
This is to close https://github.com/inveniosoftware/invenio-app-rdm/issues/2217 and closes https://github.com/zenodo/zenodo-rdm/issues/336.

The redirection for communities/<community>/about doesn't seem to work. We could rely on the redirection from invenio-rdm, instead of having to redefine it in zenodo-rdm