### PR TITLE
frontpage: replace react recent uploads component with jinja

### DIFF
--- a/assets/less/zenodo-rdm/modules/popup.overrides
+++ b/assets/less/zenodo-rdm/modules/popup.overrides
@@ -1,0 +1,44 @@
+
+.ui.label.stats-popup {
+  position: relative;
+
+  .ui.popup {
+    display: none;
+    position: absolute;
+    top: -200%;
+    width: max-content;
+
+    &:before {
+      top: 95%;
+    }
+
+  }
+
+  &#uniqueViews {
+    .ui.popup {
+      left: 0;
+
+      &:before {
+        top: 87%;
+        left: 24%;
+      }
+    }
+  }
+
+  &#uniqueDownloads {
+    .ui.popup {
+      right: 0;
+
+      &:before {
+        top: 87%;
+        right: 16%;
+      }
+    }
+  }
+
+  &:hover {
+    .ui.popup {
+      display: block !important;
+    }
+  }
+}

--- a/assets/less/zenodo-rdm/views/item.overrides
+++ b/assets/less/zenodo-rdm/views/item.overrides
@@ -7,3 +7,40 @@
         font-weight: @bold;
     }
 }
+
+
+.ui.items {
+
+    &.link > .item:hover .content .header {
+      color: @darkTextColor;
+    }
+  
+    &.carousel.page {
+      width: 100%;
+  
+      &:first-child {
+        margin: 1.5em 0 !important;
+      }
+    }
+  
+    & > .carousel.item {
+      min-width: 100%;
+    }
+  
+    .content {
+      width: 100% !important;
+  
+      &.flex.right-column {
+          flex-direction: column;
+          align-items: end;
+      };
+    }
+  }
+  
+  #records-list {
+    .ui.items {
+      li.item {
+        padding-left: 0 !important; // Needed because of override for li ~ .item
+      }
+    }
+  }

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -12,7 +12,7 @@ Only configuration created via cookiecutter or very likely to be edited
 by installer are included here.
 """
 
-from invenio_app_rdm.config import CELERY_BEAT_SCHEDULE
+from invenio_app_rdm.config import CELERY_BEAT_SCHEDULE, APP_RDM_ROUTES
 from invenio_i18n import lazy_gettext as _
 from invenio_oauthclient.contrib.openaire_aai import REMOTE_SANDBOX_APP
 from invenio_oauthclient.contrib.orcid import ORCIDOAuthSettingsHelper
@@ -27,6 +27,7 @@ from invenio_records_resources.services.records.queryparser import (
 from invenio_oauthclient.views.client import auto_redirect_login
 
 from zenodo_rdm.custom_fields import CUSTOM_FIELDS_UI, CUSTOM_FIELDS, CUSTOM_FIELDS_FACETS, NAMESPACES
+from zenodo_rdm.views import frontpage_view_function
 from zenodo_rdm.permissions import ZenodoRDMRecordPermissionPolicy
 
 # Flask
@@ -40,6 +41,7 @@ SECRET_KEY="CHANGE_ME"
 # route correct hosts to the application.
 APP_ALLOWED_HOSTS = ['0.0.0.0', 'localhost', '127.0.0.1']
 
+APP_RDM_ROUTES["index"] = ("/", frontpage_view_function)
 
 # Flask-SQLAlchemy
 # ================

--- a/site/zenodo_rdm/views.py
+++ b/site/zenodo_rdm/views.py
@@ -6,10 +6,38 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 """Additional views."""
 
-from flask import Blueprint
+from flask import Blueprint, current_app, g, render_template
+from invenio_rdm_records.proxies import current_rdm_records
+from invenio_rdm_records.resources.serializers import UIJSONSerializer
+from invenio_records_resources.resources.records.utils import search_preference
 from marshmallow import ValidationError
 
 from .support.support import ZenodoSupport
+
+
+#
+# Views
+#
+def frontpage_view_function():
+    """Zenodo frontpage view."""
+    recent_uploads = current_rdm_records.records_service.search(
+        identity=g.identity,
+        params={"sort": "newest", "size": 10},
+        search_preference=search_preference(),
+        expand=False,
+    )
+
+    records_ui = []
+
+    for record in recent_uploads:
+        record_ui = UIJSONSerializer().dump_obj(record)
+        records_ui.append(record_ui)
+
+    return render_template(
+        current_app.config["THEME_FRONTPAGE_TEMPLATE"],
+        show_intro_section=current_app.config["THEME_SHOW_FRONTPAGE_INTRO_SECTION"],
+        recent_uploads=records_ui,
+    )
 
 
 #

--- a/templates/semantic-ui/zenodo_rdm/frontpage.html
+++ b/templates/semantic-ui/zenodo_rdm/frontpage.html
@@ -22,7 +22,7 @@
   # as an Intergovernmental Organization or submit itself to any jurisdiction.
   -#}
 
-{% from "invenio_app_rdm/macros/records_list.html" import records_list %}
+{% from "zenodo_rdm/macros/recent_uploads_list.html" import recent_uploads_list %}
 {%- extends "invenio_app_rdm/frontpage.html" %}
 
 {%- block page_header %}
@@ -30,7 +30,9 @@
 {%- endblock page_header %}
 
 {% block main_column_content %}
-  {{ records_list(fetch_url=config.ZENODO_FRONTPAGE_RECENT_UPLOADS_QUERY) }}
+  {% if recent_uploads %}
+    {{ recent_uploads_list(records=recent_uploads) }}
+  {% endif %}
 {% endblock main_column_content %}
 
 {% block side_column_content %}

--- a/templates/semantic-ui/zenodo_rdm/macros/creators.html
+++ b/templates/semantic-ui/zenodo_rdm/macros/creators.html
@@ -1,0 +1,71 @@
+{#
+# This file is part of Zenodo.
+# Copyright (C) 2022 CERN.
+#
+# Zenodo is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+-#}
+
+{% macro creators(creators=None) %}
+  {% for creator in creators %}
+    {% set creator_name = creator.person_or_org.get("name", "No name") if creator.person_or_org %}
+    {% set ids = creator.person_or_org.get("identifiers", []) if creator.person_or_org %}
+
+    <span class="creatibutor-wrap separated">
+      <a
+        class="creatibutor-link"
+        href="/search?q=metadata.creators.person_or_org.name:{{ creator_name }}"
+        title="{{ creator_name }}: {{_('Search')}}"
+      >
+        <span class="creatibutor-name">{{ creator_name }}</span>
+      </a>
+
+      {{ creator_icons(creator_name=creator_name, ids=ids) }}
+    </span>
+  {% endfor%}
+{% endmacro %}
+
+
+{% macro creator_icons(creator_name=None, ids=None) %}
+  {% for id in ids %}
+    {% if id.scheme == "orcid" %}
+      {% set link = "https://orcid.org/{identifier}".format(identifier=id.identifier) %}
+      {% set link_title = _("ORCID profile") %}
+      {% set icon = "/static/images/orcid.svg" %}
+
+    {% elif id.scheme == "ror" %}
+      {% set link = "https://ror.org/{identifier}".format(identifier=id.identifier) %}
+      {% set link_title = _("ROR profile") %}
+      {% set icon = "/static/images/ror-icon.svg" %}
+
+    {% elif id.scheme == "gnd" %}
+      {% set link = "https://d-nb.info/gnd/{identifier}".format(identifier=id.identifier) %}
+      {% set link_title = _("GND profile") %}
+      {% set icon = "/static/images/gnd-icon.svg" %}
+    {% endif %}
+    <a
+      class="no-text-decoration mr-0"
+      href="{{ link }}"
+      aria-label="{{ creator_name }}: {{ link_title }}"
+      title="{{ creator_name }}: {{ link_title }}"
+    >
+      <img class="inline-id-icon ml-5" src="{{ icon }}" alt="" />
+    </a>
+  {% endfor %}
+{% endmacro %}

--- a/templates/semantic-ui/zenodo_rdm/macros/recent_uploads_list.html
+++ b/templates/semantic-ui/zenodo_rdm/macros/recent_uploads_list.html
@@ -1,0 +1,46 @@
+{#
+# This file is part of Zenodo.
+# Copyright (C) 2022 CERN.
+#
+# Zenodo is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+-#}
+
+{% from "zenodo_rdm/macros/record_item.html" import record_item %}
+
+{% macro recent_uploads_list(title="Recent uploads", records=None) %}
+  <div id="records-list" data-title="{{ title }}">
+
+    <h2 class="ui header">{{ title }}</h2>
+
+    <div class="ui container rel-mb-2 ml-0-mobile mr-0-mobile">
+      <ul class="ui divided link relaxed items pl-0">
+        {% for record in records %}
+          {{ record_item(record=record) }}
+        {% endfor %}
+      </ul>
+    </div>
+
+    <div class="ui center aligned container">
+      <a class="ui button" href="/search" aria-label="See more records">
+        More
+      </a>
+    </div>
+  </div>
+{% endmacro %}

--- a/templates/semantic-ui/zenodo_rdm/macros/record_item.html
+++ b/templates/semantic-ui/zenodo_rdm/macros/record_item.html
@@ -1,0 +1,135 @@
+{#
+# This file is part of Zenodo.
+# Copyright (C) 2022 CERN.
+#
+# Zenodo is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Zenodo is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Zenodo; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+-#}
+
+{% from "zenodo_rdm/macros/creators.html" import creators %}
+
+{% macro record_item(record=None) %}
+  <li class="item">
+    <div class="content">
+
+      {# Top labels #}
+      <div class="extra labels-actions">
+        <div class="ui small horizontal primary label">
+          {{ record.ui.publication_date_l10n_long }} ({{ record.ui.version }})
+        </div>
+        <div class="ui small horizontal neutral label">
+          {{ record.ui.resource_type.title_l10n }}
+        </div>
+
+        {% set access_status_id = record.ui.access_status.get("id", "open") %}
+        {% set access_status = record.ui.access_status.get("title_l10n", "Open") %}
+        {% set access_status_icon = record.ui.access_status.get("icon", "unlock") %}
+
+        <div class="ui small horizontal label access-status {{ access_status_id }}">
+            <i class="icon {{ access_status_icon }}" aria-hidden="true"></i>
+            {{ access_status }}
+        </div>
+      </div>
+
+      {# Title #}
+      <div class="header">
+        <a href="/records/{{ record.id }}">{{ record.metadata.title }}</a>
+      </div>
+
+      {# Creators #}
+      <div class="ui item creatibutors">
+        {% set creators_list = record.ui.creators.creators %}
+        {% set creators_sliced = creators_list[:3] %}
+
+        {{ creators(creators=creators_sliced) }}
+      </div>
+
+      {# Description #}
+      <p class="description">
+        {% set description = record.ui.get("description_stripped", "No description") %}
+
+        {{ description | truncate(length=350, end='...') }}
+      </p>
+
+      <div class="extra">
+        <div class="flex justify-space-between align-items-end">
+          {# Publishing details #}
+          {% set created_date = record.ui.created_date_l10n_long %}
+          {% set publishing_journal = record.ui.publishing_information.get("journal") if record.ui.publishing_information %}
+
+          <small>
+            {% if created_date %}
+              {{ _("Uploaded on:")}} {{ created_date }}
+            {% endif %}
+
+            {% if publishing_journal %}
+              {{ _("Published in:") }} {{ publishing_journal }}
+            {% endif %}
+          </small>
+
+          {# Versions info desktop/tablet #}
+          {% if record.versions.index > 1 %}
+            {% set num_versions = record.versions.index %}
+            {% set text_content = _("more versions exist for this record") %}
+            {% if num_versions == 2 %}
+              {% set text_content = _("more version exist for this record") %}
+            {% endif %}
+
+            <small class="computer tablet only">
+              <p>{{ record.versions.index - 1 }} {{ text_content }}</p>
+            </small>
+          {% endif %}
+
+          {# Statistics #}
+          {% set unique_downloads = record.stats.all_versions.unique_downloads %}
+          {% set unique_views = record.stats.all_versions.unique_views %}
+
+          <small>
+            {% if unique_views is defined %}
+              <div id="uniqueViews" class="ui transparent label stats-popup">
+                <i class="ui eye icon" aria-label="{{ _('Unique views') }}"></i>
+                {{ unique_views }}
+                <div class="ui tiny popup">
+                  {{ _("Unique views") }}
+                </div>
+              </div>
+            {% endif %}
+
+            {% if unique_downloads is defined %}
+              <div id="uniqueDownloads" class="ui transparent label stats-popup">
+                <i class="ui download icon" aria-label="{{ _('Unique downloads') }}"></i>
+                {{ unique_downloads}}
+                <div class="ui tiny popup">
+                  {{ _("Unique downloads") }}
+                </div>
+              </div>
+            {% endif %}
+          </small>
+        </div>
+
+        {# Versions info mobile #}
+        {% if record.versions.index > 1 %}
+          <small class="mobile only">
+            <p>{{ record.versions.index - 1 }} {{ text_content }}</p>
+          </small>
+      {% endif %}
+      </div>
+    </div>
+  </li>
+{% endmacro %}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2268

Replaces React "recent uploads"-component on the front page.

## Screenshots

## Desktop
<img width="1266" alt="Screenshot 2023-07-05 at 11 47 57" src="https://github.com/zenodo/zenodo-rdm/assets/21052053/28ec1ce1-bcd0-4a5b-a83c-808da9aaa37a">

## Tablet
<img width="785" alt="Screenshot 2023-07-05 at 11 47 49" src="https://github.com/zenodo/zenodo-rdm/assets/21052053/e77a380c-04c1-4dd9-aab3-2f83191a6638">


## Mobile
<img width="511" alt="Screenshot 2023-07-05 at 11 47 39" src="https://github.com/zenodo/zenodo-rdm/assets/21052053/3ef5305e-2a90-4132-b027-590a6df90023">

### CSS-only popup (on hover)

<img width="191" alt="Screenshot 2023-07-05 at 11 49 39" src="https://github.com/zenodo/zenodo-rdm/assets/21052053/22e88cfc-14e9-4ca7-ba28-a03b350ad1e2">
<img width="165" alt="Screenshot 2023-07-05 at 11 49 43" src="https://github.com/zenodo/zenodo-rdm/assets/21052053/97d83c78-4c6b-472f-ade4-10bda2a24fe8">



