### PR TITLE
frontpage: remove need help block

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/frontpage.html
+++ b/templates/semantic-ui/zenodo_rdm/frontpage.html
@@ -44,25 +44,6 @@
 
 {% block side_column_content %}
   <section class="sidebar-container">
-    <h2 class="ui medium top attached header mt-0">{{ _("Need help?") }} </h2>
-    <div class="ui segment bottom attached rdm-sidebar">
-      <a href="/support" class="ui button fluid rel-mb-1">Contact us</a>
-      <p>
-        Zenodo prioritizes all requested related to the COVID-19 outbreak.
-
-        We can help with:
-
-          <ul class="mb-0">
-            <li>Uploading your research data, software, preprints, etc.</li>
-            <li>One-on-one with Zenodo supporters.</li>
-            <li>Quota increases beyond our default policy.</li>
-            <li>Scripts for automated uploading of larger datasets.</li>
-          </ul>
-      </p>
-    </div>
-  </section>
-
-  <section class="sidebar-container">
     <h2 class="ui medium top attached header mt-0">{{ _("Why use Zenodo?") }} </h2>
     <div class="ui segment bottom attached rdm-sidebar">
       <ul class="m-0">


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/210

Removes "Need help?" block from the front page.