### PR TITLE
communities: don't allow creation of restricted communities

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -377,3 +377,5 @@ RDM_CUSTOM_FIELDS_UI = CUSTOM_FIELDS_UI  #  UI components
 # Invenio-Communities
 # ==============
 COMMUNITIES_GROUPS_ENABLED = False
+
+COMMUNITIES_ALLOW_RESTRICTED = False


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/218

Note: current permission logic doesn't allow to create restricted community to anyone: https://github.com/inveniosoftware/invenio-communities/blob/0a1f038cb16063cc03e6ff6b5cb6635dc05a0f0b/invenio_communities/permissions.py#L58