### PR TITLE
carousel: fix broken link

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/macros/carousel_item.html
+++ b/templates/semantic-ui/zenodo_rdm/macros/carousel_item.html
@@ -36,13 +36,15 @@
         <div class="six wide computer sixteen wide tablet column buttons">
           <a
             class="ui mini button"
-            href={community.links.self_html}
+            href="{{ community.links.self_html }}"
+            aria-label="Browse {{ community.metadata.title }}"
           >
             {{ _("Browse") }}
           </a>
           <a
             class="ui mini icon positive left labeled button"
             href="/uploads/new?community={{community.slug}}"
+            aria-label="Create new upload in {{ community.metadata.title }}"
           >
             <i class="upload icon" aria-hidden="true"></i>
             {{ _("New upload") }}


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/233

- Fixes broken link
- Adds more descriptive link text for screen readers