### PR TITLE
redirection: add legacy formats -> media-files URL redirect

### DIFF
--- a/site/zenodo_rdm/config.py
+++ b/site/zenodo_rdm/config.py
@@ -21,6 +21,7 @@ from .redirector import (
     redirect_record_file_preview_view,
     redirect_record_thumbnail_view,
     search_view_function,
+    redirect_formats_to_media_files_view
 )
 
 # Silent warnings
@@ -300,6 +301,10 @@ REDIRECTOR_RULES = {
         "source": "/record/<pid_value>/thumb<size>",
         "target": redirect_record_thumbnail_view,
     },
+    "redirect_formats_to_media_files": {
+        "source": "/record/<pid_value>/formats",
+        "target": redirect_formats_to_media_files_view
+    }
 }
 
 EXPORT_REDIRECTS = {

--- a/site/zenodo_rdm/config.py
+++ b/site/zenodo_rdm/config.py
@@ -18,10 +18,10 @@ from .redirector import (
     record_view_function,
     redirect_deposit_new_view,
     redirect_deposit_own_view,
+    redirect_formats_to_media_files_view,
     redirect_record_file_preview_view,
     redirect_record_thumbnail_view,
     search_view_function,
-    redirect_formats_to_media_files_view
 )
 
 # Silent warnings
@@ -303,8 +303,8 @@ REDIRECTOR_RULES = {
     },
     "redirect_formats_to_media_files": {
         "source": "/record/<pid_value>/formats",
-        "target": redirect_formats_to_media_files_view
-    }
+        "target": redirect_formats_to_media_files_view,
+    },
 }
 
 EXPORT_REDIRECTS = {

--- a/site/zenodo_rdm/redirector.py
+++ b/site/zenodo_rdm/redirector.py
@@ -242,6 +242,7 @@ def redirect_deposit_new_view():
     target = url_for("invenio_app_rdm_records.deposit_create", **values)
     return target
 
+
 def redirect_record_thumbnail_view():
     """Redirect legacy record thumbnail URL.
 
@@ -250,18 +251,19 @@ def redirect_record_thumbnail_view():
     """
     return url_for("invenio_app_rdm_records.record_thumbnail", **request.view_args)
 
+
 def redirect_formats_to_media_files_view():
-    """Implements redirector view function for formats retrieval.
+    """Redirect formats to media files URLs.
 
     The following routes are redirected as follows:
-        -  /record/<pid_value>?mimetype=<filename> -> GET /records/<pid_value>/media-files/<filename>
+        - /record/<pid_value>/formats?mimetype=<filename> -> GET /records/<pid_value>/media-files/<filename>
 
     :return: url for the view 'invenio_app_rdm_records.record_media_file_download'
     :rtype: str
     """
     values = request.view_args
     filename = request.args.get("mimetype", None)
-    values['filename'] = filename
+    values["filename"] = filename
 
     target = url_for("invenio_app_rdm_records.record_media_file_download", **values)
     return target

--- a/site/zenodo_rdm/redirector.py
+++ b/site/zenodo_rdm/redirector.py
@@ -242,7 +242,6 @@ def redirect_deposit_new_view():
     target = url_for("invenio_app_rdm_records.deposit_create", **values)
     return target
 
-
 def redirect_record_thumbnail_view():
     """Redirect legacy record thumbnail URL.
 
@@ -250,3 +249,19 @@ def redirect_record_thumbnail_view():
         - /record/<pid_value>/thumb<size> -> /records/<pid_value>/thumb<size>
     """
     return url_for("invenio_app_rdm_records.record_thumbnail", **request.view_args)
+
+def redirect_formats_to_media_files_view():
+    """Implements redirector view function for formats retrieval.
+
+    The following routes are redirected as follows:
+        -  /record/<pid_value>?mimetype=<filename> -> GET /records/<pid_value>/media-files/<filename>
+
+    :return: url for the view 'invenio_app_rdm_records.record_media_file_download'
+    :rtype: str
+    """
+    values = request.view_args
+    filename = request.args.get("mimetype", None)
+    values['filename'] = filename
+
+    target = url_for("invenio_app_rdm_records.record_media_file_download", **values)
+    return target


### PR DESCRIPTION
Partially fixes #482

This PR covers redirect from requests of type
`https://zenodo.org/record/8321034/formats?mimetype=figure.png` -> `https://zenodo.org/records/8321034/media-files/figure.png`
___
The other case with `Accept` header:
```python3
resp = requests.get(
    "https://zenodo.org/record/8321034/formats",
    headers={"Accept": "application/vnd.taxpub.v1+xml"},
)
```
 is not a straightforward fix given the value of `Accept` is equal to the filename. So the only requests that go through are when filename = valid mimetype. If we have a request of type:
```python3
resp = requests.get(
    "https://zenodo.org/record/8321034/formats",
    headers={"Accept": "figure.png"},
)
```
The application itself doesn't let it go through given `figure.png` is not a valid mimetype. We can probably track it as a separate issue.

