### PR TITLE
legacy: fix legacy files api when published

### DIFF
--- a/site/zenodo_rdm/legacy/serializers/__init__.py
+++ b/site/zenodo_rdm/legacy/serializers/__init__.py
@@ -8,9 +8,15 @@
 """Zenodo legacy serializers."""
 
 from flask_resources import BaseListSchema, JSONSerializer, MarshmallowSerializer
-from marshmallow import post_dump
+from marshmallow import fields, post_dump
 
-from .schemas import LegacyFileSchema, LegacyFilesRESTSchema, LegacySchema, ZenodoSchema
+from .schemas import (
+    LegacyFileListSchema,
+    LegacyFileSchema,
+    LegacyFilesRESTSchema,
+    LegacySchema,
+    ZenodoSchema,
+)
 
 
 class LegacyListSchema(BaseListSchema):
@@ -59,7 +65,7 @@ class LegacyDraftFileJSONSerializer(MarshmallowSerializer):
         super().__init__(
             format_serializer_cls=JSONSerializer,
             object_schema_cls=LegacyFileSchema,
-            list_schema_cls=LegacyListSchema,
+            list_schema_cls=LegacyFileListSchema,
         )
 
 

--- a/site/zenodo_rdm/legacy/serializers/schemas/__init__.py
+++ b/site/zenodo_rdm/legacy/serializers/schemas/__init__.py
@@ -7,13 +7,14 @@
 
 """Zenodo legacy services."""
 
-from .files import LegacyFileSchema, LegacyFilesRESTSchema
+from .files import LegacyFileListSchema, LegacyFileSchema, LegacyFilesRESTSchema
 from .legacyjson import LegacySchema
 from .zenodojson import ZenodoSchema
 
 __all__ = (
-    "LegacySchema",
+    "LegacyFileListSchema",
     "LegacyFileSchema",
     "LegacyFilesRESTSchema",
+    "LegacySchema",
     "ZenodoSchema",
 )

--- a/site/zenodo_rdm/legacy/serializers/schemas/files.py
+++ b/site/zenodo_rdm/legacy/serializers/schemas/files.py
@@ -7,7 +7,7 @@
 
 """Zenodo legacy files schemas."""
 
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, post_dump
 from marshmallow_utils.fields import SanitizedUnicode
 
 
@@ -53,3 +53,14 @@ class LegacyFilesRESTSchema(Schema):
             for k, v in obj["links"].items()
             if k.startswith("files_rest.")
         }
+
+
+class LegacyFileListSchema(Schema):
+    """Files list schema."""
+
+    entries = fields.List(fields.Nested(LegacyFileSchema), dump_only=True)
+
+    @post_dump()
+    def unwrap(self, data, many, **kwargs):
+        """Unwrap into a top-level array."""
+        return data.get("entries", [])

--- a/site/zenodo_rdm/legacy/serializers/schemas/files.py
+++ b/site/zenodo_rdm/legacy/serializers/schemas/files.py
@@ -37,7 +37,7 @@ class LegacyFilesRESTSchema(Schema):
 
     version_id = SanitizedUnicode()
     key = SanitizedUnicode()
-    size = fields.Number()
+    size = fields.Integer()
     mimetype = SanitizedUnicode()
     checksum = SanitizedUnicode()
 

--- a/templates/semantic-ui/zenodo_rdm/footer.html
+++ b/templates/semantic-ui/zenodo_rdm/footer.html
@@ -45,6 +45,9 @@
         <a href="https://about.zenodo.org/projects/">{{_('Projects')}}</a>
       </li>
       <li class="item">
+        <a href="https://about.zenodo.org/roadmap/">{{ _('Roadmap') }}</a>
+      </li>
+      <li class="item">
         <a href="https://about.zenodo.org/contact">{{_('Contact')}}</a>
       </li>
     </ul>
@@ -64,19 +67,10 @@
         <a href="https://help.zenodo.org">{{_('FAQ')}}</a>
       </li>
       <li class="item">
-        <a href="https://help.zenodo.org/features">{{_('Features')}}</a>
-      </li>
-      <li class="item">
-        <a href="https://help.zenodo.org/whatsnew">{{_("What's New")}}</a>
-      </li>
-      <li class="item">
-        <a href="https://about.zenodo.org/roadmap/">{{ _('Roadmap') }}</a>
+        <a href="https://help.zenodo.org/docs/">{{ _('Docs') }}</a>
       </li>
       <li class="item">
         <a href="https://help.zenodo.org/guides/">{{ _('Guides') }}</a>
-      </li>
-      <li class="item">
-        <a href="https://help.zenodo.org/docs/">{{ _('Docs') }}</a>
       </li>
       <li class="item">
         <a href="https://www.zenodo.org/support/">{{ _('Support') }}</a>
@@ -127,7 +121,7 @@
       </a>
     </li>
     <li class="item">
-      <a href="https://ec.europa.eu/programmes/horizon2020/" aria-label="European Commission">
+      <a href="https://commission.europa.eu/index_en" aria-label="European Commission">
         <img src="{{ url_for('static', filename='images/eu.png') }}" width="88" height="60" alt="" />
       </a>
     </li>
@@ -141,7 +135,7 @@
     <div class="ui grid">
       <div class="eight wide column left middle aligned">
         <p class="m-0">
-          Powered by 
+          Powered by
           <a href="http://information-technology.web.cern.ch/about/computer-centre">CERN Data Centre</a> & <a href="https://inveniordm.docs.cern.ch/">InvenioRDM</a>
         </p>
       </div>


### PR DESCRIPTION
Fixes issues with ``/api/deposit/depositions/:id/files``:

1. Endpoint didn't work with a published record - i.e. you could list files only on a draft, not on a published record.
2. Serialisation on above endpoint was broken - service result (obj_list) have "entries" and not "hits".

Sneaked in a menu update as well.