### PR TITLE
legacy: serializers: return empty list if files not present

### DIFF
--- a/site/zenodo_rdm/legacy/serializers/schemas/legacyjson.py
+++ b/site/zenodo_rdm/legacy/serializers/schemas/legacyjson.py
@@ -154,7 +154,7 @@ class LegacySchema(common.LegacySchema):
                     "links": links,
                 }
             )
-        return result or missing
+        return result
 
     @pre_dump
     def hook_metadata(self, data, **kwargs):


### PR DESCRIPTION
Fixes https://github.com/zenodo/rdm-project/issues/286