### PR TITLE
config: re-enable openaire oauth app.

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -432,7 +432,7 @@ OAUTHCLIENT_OPENAIRE_AAI_USER_INFO_URL = "https://aai.openaire.eu/auth/realms/op
 OAUTHCLIENT_REMOTE_APPS = {
     "orcid": _orcid_helper.remote_app,
     "github": github_remote_app,
-    # "openaire_aai": _openaire_helper.remote_app,
+    "openaire_aai": _openaire_helper.remote_app,
 }
 OAUTHCLIENT_REST_REMOTE_APPS = {
     "github": github_remote_app,


### PR DESCRIPTION
closes https://github.com/zenodo/rdm-project/issues/371

@slint it seems to me that the client ID was updated on OpenAIRE side and the issue should be fixed ™️ , however can only test it when we deploy. 