### PR TITLE
legacy: relax data handling to avoid errors

### DIFF
--- a/site/zenodo_rdm/legacy/serializers/schemas/common.py
+++ b/site/zenodo_rdm/legacy/serializers/schemas/common.py
@@ -71,7 +71,7 @@ class CreatorSchema(Schema):
     def dump_affiliation(self, obj):
         """Dump affiliation."""
         if obj.get("affiliations"):
-            return obj["affiliations"][0]["name"]
+            return obj["affiliations"][0].get("name")
 
     @post_dump(pass_original=True)
     def dump_identifiers(self, result, original, **kwargs):


### PR DESCRIPTION
* Handles error when an affiliation didn't have a name.