### PR TITLE
sitemap: store only urls to cache

### DIFF
--- a/site/zenodo_rdm/sitemap/tasks.py
+++ b/site/zenodo_rdm/sitemap/tasks.py
@@ -32,10 +32,9 @@ def update_sitemap_cache(urls=None, max_url_count=None):
         sitemap.clear_cache()
         while urls_slice:
             page_n += 1
-            page = render_template(
-                "zenodo_sitemap/sitemap.xml", urlset=filter(None, urls_slice)
-            )
-            sitemap.set_cache(f"sitemap:{page_n}", page)
+            sitemap.set_cache(
+                f"sitemap:{page_n}", urls_slice
+            )  # Cache only the URLs and render the page on request
             urls_slice = list(itertools.islice(urls, max_url_count))
 
         urlset = [

--- a/site/zenodo_rdm/sitemap/views.py
+++ b/site/zenodo_rdm/sitemap/views.py
@@ -7,7 +7,7 @@
 
 """Redirects for legacy URLs."""
 
-from flask import Blueprint, abort, current_app
+from flask import Blueprint, abort, current_app, render_template
 from invenio_cache import current_cache
 
 blueprint = Blueprint(
@@ -21,6 +21,8 @@ blueprint = Blueprint(
 
 def _get_cached_or_404(page):
     data = current_cache.get("sitemap:" + str(page))
+    if page != 0:
+        data = render_template("zenodo_sitemap/sitemap.xml", urlset=filter(None, data))
     if data:
         return current_app.response_class(data, mimetype="text/xml")
     else:


### PR DESCRIPTION
Fixes https://github.com/zenodo/rdm-project/issues/559

After deploying this change, please run:

```python3
from zenodo_rdm.sitemap.tasks import update_sitemap_cache
update_sitemap_cache()
```