### PR TITLE
landing page: add blr related works section

### DIFF
--- a/assets/less/zenodo-rdm/globals/site.overrides
+++ b/assets/less/zenodo-rdm/globals/site.overrides
@@ -139,3 +139,8 @@ a.inverted {
     font-size: 1.45rem;
   }
 }
+
+.image.thumbnail-image {
+  height: 150px;
+  object-fit: cover;
+}

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/BlrSearch.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/BlrSearch.js
@@ -1,0 +1,118 @@
+// This file is part of Zenodo.
+// Copyright (C) 2023 CERN.
+//
+// Zenodo is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// Zenodo is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zenodo; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+// MA 02111-1307, USA.
+//
+// In applying this license, CERN does not
+// waive the privileges and immunities granted to it by virtue of its status
+// as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  ReactSearchKit,
+  InvenioSearchApi,
+  ResultsLoader,
+  ResultsMultiLayout,
+  Error,
+  EmptyResults,
+  Pagination,
+  BucketAggregation,
+  LayoutSwitcher,
+} from "react-searchkit";
+import { OverridableContext } from "react-overridable";
+import { apiConfig } from "./api/config";
+import { Segment, Container, Header } from "semantic-ui-react";
+import { ResultsGridLayout, ResultsListLayout } from "./components/ResultsLayout";
+import { RecordGridItem, RecordListItem } from "./components/RecordItem";
+import { FilterContainer, Filter, FilterValues } from "./components/Filter";
+import { LayoutSwitchButtons } from "./components/LayoutSwitchButtons";
+import { NoResults } from "./components/NoResults";
+
+const blrSearchAppID = "blrSearch";
+
+const overriddenComponents = {
+  [`${blrSearchAppID}.ResultsGrid.container`]: ResultsGridLayout,
+  [`${blrSearchAppID}.ResultsGrid.item`]: RecordGridItem,
+  [`${blrSearchAppID}.ResultsList.container`]: ResultsListLayout,
+  [`${blrSearchAppID}.ResultsList.item`]: RecordListItem,
+  [`${blrSearchAppID}.BucketAggregation.element`]: FilterContainer,
+  [`${blrSearchAppID}.BucketAggregationContainer.element`]: Filter,
+  [`${blrSearchAppID}.BucketAggregationValues.element`]: FilterValues,
+  [`${blrSearchAppID}.LayoutSwitcher.element`]: LayoutSwitchButtons,
+  [`${blrSearchAppID}.EmptyResults.element`]: NoResults,
+};
+
+export const BlrSearch = ({ endpoint, recordDOI, resourceType }) => {
+  const relationType = (resourceType) =>
+    resourceType === "Journal article" || resourceType === "Book chapter"
+      ? "ispartof"
+      : "haspart";
+
+  const queryString = (relationType, identifier) =>
+    `metadata.related_identifiers.relation_type.id:${relationType} AND metadata.related_identifiers.identifier:"${identifier}"`;
+
+  const searchApi = new InvenioSearchApi(apiConfig(endpoint));
+
+  const initialState = {
+    queryString: queryString(relationType(resourceType), recordDOI),
+    sortBy: "bestmatch",
+    sortOrder: "asc",
+    page: 1,
+    size: 4,
+    layout: "list",
+  };
+
+  return (
+    <>
+      <Header as="h2">Linked records</Header>
+      <OverridableContext.Provider value={overriddenComponents}>
+        <ReactSearchKit
+          appName={blrSearchAppID}
+          searchApi={searchApi}
+          urlHandlerApi={{ enabled: false }}
+          initialQueryState={initialState}
+        >
+          <>
+            <div className="flex align-items-center justify-space-between">
+              <BucketAggregation
+                agg={{ field: "resource_type", aggName: "resource_type" }}
+              />
+              <LayoutSwitcher />
+            </div>
+
+            <Segment>
+              <ResultsLoader>
+                <ResultsMultiLayout />
+                <Error />
+                <EmptyResults />
+              </ResultsLoader>
+              <Container align="center" className="rel-pt-1">
+                <Pagination options={{ size: "mini", showEllipsis: true }} />
+              </Container>
+            </Segment>
+          </>
+        </ReactSearchKit>
+      </OverridableContext.Provider>
+    </>
+  );
+};
+
+BlrSearch.propTypes = {
+  endpoint: PropTypes.string.isRequired,
+  recordDOI: PropTypes.string.isRequired,
+  resourceType: PropTypes.string.isRequired,
+};

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/api/config.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/api/config.js
@@ -1,0 +1,31 @@
+// This file is part of Zenodo.
+// Copyright (C) 2023 CERN.
+//
+// Zenodo is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// Zenodo is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zenodo; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+// MA 02111-1307, USA.
+//
+// In applying this license, CERN does not
+// waive the privileges and immunities granted to it by virtue of its status
+// as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+export const apiConfig = (endpoint) => ({
+  axios: {
+    url: endpoint,
+    timeout: 5000,
+    headers: {
+      Accept: "application/vnd.inveniordm.v1+json",
+    },
+  },
+});

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/BlrResultsLoader.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/BlrResultsLoader.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { Placeholder } from "semantic-ui-react";
+
+export const BlrResultsLoader = (children, loading) => {
+  return loading ? (
+    <Placeholder fluid>
+      <Placeholder.Header image>
+        <Placeholder.Line length="long" />
+        <Placeholder.Line />
+      </Placeholder.Header>
+      <Placeholder.Header image>
+        <Placeholder.Line length="long" />
+        <Placeholder.Line />
+      </Placeholder.Header>
+    </Placeholder>
+  ) : (
+    children
+  );
+};

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/Filter.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/Filter.js
@@ -1,0 +1,92 @@
+// This file is part of Zenodo.
+// Copyright (C) 2023 CERN.
+//
+// Zenodo is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// Zenodo is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zenodo; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+// MA 02111-1307, USA.
+//
+// In applying this license, CERN does not
+// waive the privileges and immunities granted to it by virtue of its status
+// as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import React from "react";
+import { PropTypes } from "prop-types";
+import { Dropdown, Label, Button, Icon } from "semantic-ui-react";
+import { withState } from "react-searchkit";
+
+export const FilterContainer = ({ agg, containerCmp, updateQueryFilters }) => {
+  const clearFacets = () => {
+    if (containerCmp.props.selectedFilters.length) {
+      updateQueryFilters([agg.aggName, ""], containerCmp.props.selectedFilters);
+    }
+  };
+
+  return (
+    <div className="flex align-items-center">
+      <div>{containerCmp}</div>
+      <div>
+        <Button onClick={clearFacets} content="Reset filters" />
+      </div>
+    </div>
+  );
+};
+
+FilterContainer.propTypes = {
+  agg: PropTypes.object.isRequired,
+  updateQueryFilters: PropTypes.func.isRequired,
+  containerCmp: PropTypes.node.isRequired,
+};
+
+export const Filter = withState(({ currentQueryState, valuesCmp }) => {
+  const numSelectedFilters = currentQueryState.filters.length;
+  return (
+    <Dropdown
+      text={`Filter by type ${numSelectedFilters ? `(${numSelectedFilters})` : ""}`}
+      button
+    >
+      <Dropdown.Menu>{valuesCmp}</Dropdown.Menu>
+    </Dropdown>
+  );
+});
+
+Filter.propTypes = {
+  valuesCmp: PropTypes.array.isRequired,
+};
+
+export const FilterValues = ({ bucket, isSelected, onFilterClicked, label }) => {
+  return (
+    <Dropdown.Item
+      key={bucket.key}
+      id={`${bucket.key}-agg-value`}
+      selected={isSelected}
+      onClick={() => onFilterClicked(bucket.key)}
+      value={bucket.key}
+      className="flex align-items-center justify-space-between"
+    >
+      {isSelected && <Icon name="check" className="positive" />}
+
+      <span>{label}</span>
+      <Label size="small" className="rel-ml-1 mr-0">
+        {bucket.doc_count.toLocaleString("en-US")}
+      </Label>
+    </Dropdown.Item>
+  );
+};
+
+FilterValues.propTypes = {
+  bucket: PropTypes.object.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  onFilterClicked: PropTypes.func.isRequired,
+  label: PropTypes.string.isRequired,
+};

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/LayoutSwitchButtons.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/LayoutSwitchButtons.js
@@ -1,0 +1,51 @@
+// This file is part of Zenodo.
+// Copyright (C) 2023 CERN.
+//
+// Zenodo is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// Zenodo is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zenodo; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+// MA 02111-1307, USA.
+//
+// In applying this license, CERN does not
+// waive the privileges and immunities granted to it by virtue of its status
+// as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import React from "react";
+import { PropTypes } from "prop-types";
+import { Button } from "semantic-ui-react";
+
+export const LayoutSwitchButtons = ({ currentLayout, onLayoutChange }) => {
+  return (
+    <Button.Group>
+      <Button
+        icon="th list"
+        name="list"
+        active={currentLayout === "list"}
+        onClick={() => onLayoutChange("list")}
+        aria-label="List view"
+      />
+      <Button
+        icon="th"
+        name="grid"
+        active={currentLayout === "grid"}
+        onClick={() => onLayoutChange("grid")}
+        aria-label="Grid view"
+      />
+    </Button.Group>
+  );
+};
+
+LayoutSwitchButtons.propTypes = {
+  currentLayout: PropTypes.string.isRequired,
+  onLayoutChange: PropTypes.func.isRequired,
+};

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/NoResults.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/NoResults.js
@@ -21,33 +21,14 @@
 // as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 import React from "react";
-import { PropTypes } from "prop-types";
-import { Container, Icon } from "semantic-ui-react";
+import { Container } from "semantic-ui-react";
 
-export const NoResults = ({ queryString }) => {
+export const NoResults = () => {
   return (
-    <Container align={(!queryString && "left") || "center"}>
-      {(queryString && (
-        <div className="text-muted rel-p-1">
-          <Icon name="search" size="huge" />
-          <p className="rel-mt-1">
-            <strong>No results found for '{queryString}'</strong>
-          </p>
-        </div>
-      )) || (
-        <p>
-          <Icon name="folder open outline" />
-          <em>No related content for this record.</em>
-        </p>
-      )}
+    <Container align="left">
+      <p>
+        <em>No related content for this record</em>
+      </p>
     </Container>
   );
-};
-
-NoResults.propTypes = {
-  queryString: PropTypes.string,
-};
-
-NoResults.defaultProps = {
-  queryString: "",
 };

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/NoResults.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/NoResults.js
@@ -1,0 +1,53 @@
+// This file is part of Zenodo.
+// Copyright (C) 2023 CERN.
+//
+// Zenodo is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// Zenodo is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zenodo; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+// MA 02111-1307, USA.
+//
+// In applying this license, CERN does not
+// waive the privileges and immunities granted to it by virtue of its status
+// as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import React from "react";
+import { PropTypes } from "prop-types";
+import { Container, Icon } from "semantic-ui-react";
+
+export const NoResults = ({ queryString }) => {
+  return (
+    <Container align={(!queryString && "left") || "center"}>
+      {(queryString && (
+        <div className="text-muted rel-p-1">
+          <Icon name="search" size="huge" />
+          <p className="rel-mt-1">
+            <strong>No results found for '{queryString}'</strong>
+          </p>
+        </div>
+      )) || (
+        <p>
+          <Icon name="folder open outline" />
+          <em>No related content for this record.</em>
+        </p>
+      )}
+    </Container>
+  );
+};
+
+NoResults.propTypes = {
+  queryString: PropTypes.string,
+};
+
+NoResults.defaultProps = {
+  queryString: "",
+};

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/RecordItem.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/RecordItem.js
@@ -1,0 +1,126 @@
+// This file is part of Zenodo.
+// Copyright (C) 2023 CERN.
+//
+// Zenodo is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// Zenodo is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zenodo; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+// MA 02111-1307, USA.
+//
+// In applying this license, CERN does not
+// waive the privileges and immunities granted to it by virtue of its status
+// as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Grid, Header, Item, Label, Icon } from "semantic-ui-react";
+import _get from "lodash/get";
+import { SearchItemCreators } from "@js/invenio_app_rdm/utils";
+import { Image } from "react-invenio-forms";
+
+const layoutProps = (result) => ({
+  accessStatusId: _get(result, "ui.access_status.id", "open"),
+  accessStatus: _get(result, "ui.access_status.title_l10n", "Open"),
+  accessStatusIcon: _get(result, "ui.access_status.icon", "unlock"),
+  createdDate: _get(result, "ui.created_date_l10n_long", "Unknown date"),
+  creators: _get(result, "ui.creators.creators", []).slice(0, 3),
+  resourceType: _get(result, "ui.resource_type.title_l10n", "No resource type"),
+  title: _get(result, "metadata.title", "No title"),
+  link: _get(result, "links.self_html", "#"),
+  typeIcon: result.ui?.resource_type?.id.includes("image") ? "image" : "file alternate",
+});
+
+export const RecordGridItem = ({ result }) => {
+  const { title, creators, resourceType, typeIcon, link } = layoutProps(result);
+
+  return (
+    <Grid.Column className="flex column">
+      <Image
+        src={`${result.links.self_html}/thumb250`}
+        className="thumbnail-image mb-10"
+      />
+      <div>
+        <div className="pb-10">
+          <Label horizontal size="small">
+            <Icon name={typeIcon} />
+            {resourceType}
+          </Label>
+        </div>
+
+        <Header href={link} className="ui small header truncate-lines-2 m-0">
+          {title}
+        </Header>
+
+        <SearchItemCreators creators={creators} />
+      </div>
+    </Grid.Column>
+  );
+};
+
+RecordGridItem.propTypes = {
+  result: PropTypes.object.isRequired,
+};
+
+export const RecordListItem = ({ result }) => {
+  const {
+    accessStatusId,
+    accessStatus,
+    accessStatusIcon,
+    createdDate,
+    creators,
+    resourceType,
+    title,
+    typeIcon,
+    link,
+  } = layoutProps(result);
+
+  return (
+    <Item>
+      <Image
+        size="tiny"
+        src={`${result.links.self_html}/thumb250`}
+        className="thumbnail-image"
+      />
+
+      <Item.Content>
+        <div className="pb-10">
+          <Label horizontal size="small">
+            <Icon name={typeIcon} />
+            {resourceType}
+          </Label>
+
+          <Label horizontal size="small" className="primary">
+            <Icon name="calendar alternate" />
+            {createdDate}
+          </Label>
+
+          <Label horizontal size="small" className={`access-status ${accessStatusId}`}>
+            {accessStatusIcon && <Icon name={accessStatusIcon} />}
+            {accessStatus}
+          </Label>
+        </div>
+
+        <Item.Header href={link} className="ui small header">
+          {title}
+        </Item.Header>
+
+        <Item.Extra>
+          <SearchItemCreators creators={creators} />
+        </Item.Extra>
+      </Item.Content>
+    </Item>
+  );
+};
+
+RecordListItem.propTypes = {
+  result: PropTypes.object.isRequired,
+};

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/ResultsLayout.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/ResultsLayout.js
@@ -1,0 +1,45 @@
+// This file is part of Zenodo.
+// Copyright (C) 2023 CERN.
+//
+// Zenodo is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// Zenodo is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zenodo; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+// MA 02111-1307, USA.
+//
+// In applying this license, CERN does not
+// waive the privileges and immunities granted to it by virtue of its status
+// as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Grid, Item } from "semantic-ui-react";
+
+export const ResultsListLayout = ({ results }) => (
+  <Item.Group unstackable divided relaxed link>
+    {results}
+  </Item.Group>
+);
+
+ResultsListLayout.propTypes = {
+  results: PropTypes.array.isRequired,
+};
+
+export const ResultsGridLayout = ({ results }) => (
+  <Grid columns="4" doubling>
+    {results}
+  </Grid>
+);
+
+ResultsGridLayout.propTypes = {
+  results: PropTypes.array.isRequired,
+};

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/index.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/index.js
@@ -28,23 +28,15 @@ const blrContainer = document.getElementById("blr-search");
 const endpoint = blrContainer.dataset.blrEndpoint;
 const recordDOI = JSON.parse(blrContainer.dataset.recordDoi);
 const resourceType = JSON.parse(blrContainer.dataset.resourceType);
+const blrId = JSON.parse(blrContainer.dataset.blrId);
 
-const validTypes = [
-  "Figure",
-  "Taxonomic treatment",
-  "Book chapter",
-  "Journal article",
-  "Drawing",
-];
-
-if (validTypes.includes(resourceType)) {
-  blrContainer &&
-    ReactDOM.render(
-      <BlrSearch
-        endpoint={endpoint}
-        recordDOI={recordDOI}
-        resourceType={resourceType}
-      />,
-      blrContainer
-    );
-}
+blrContainer &&
+  ReactDOM.render(
+    <BlrSearch
+      endpoint={endpoint}
+      recordDOI={recordDOI}
+      resourceType={resourceType}
+      blrId={blrId}
+    />,
+    blrContainer
+  );

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/index.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/index.js
@@ -1,0 +1,50 @@
+// This file is part of Zenodo.
+// Copyright (C) 2023 CERN.
+//
+// Zenodo is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation; either version 2 of the
+// License, or (at your option) any later version.
+//
+// Zenodo is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zenodo; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+// MA 02111-1307, USA.
+//
+// In applying this license, CERN does not
+// waive the privileges and immunities granted to it by virtue of its status
+// as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { BlrSearch } from "./BlrSearch";
+
+const blrContainer = document.getElementById("blr-search");
+const endpoint = blrContainer.dataset.blrEndpoint;
+const recordDOI = JSON.parse(blrContainer.dataset.recordDoi);
+const resourceType = JSON.parse(blrContainer.dataset.resourceType);
+
+const validTypes = [
+  "Figure",
+  "Taxonomic treatment",
+  "Book chapter",
+  "Journal article",
+  "Drawing",
+];
+
+if (validTypes.includes(resourceType)) {
+  blrContainer &&
+    ReactDOM.render(
+      <BlrSearch
+        endpoint={endpoint}
+        recordDOI={recordDOI}
+        resourceType={resourceType}
+      />,
+      blrContainer
+    );
+}

--- a/site/zenodo_rdm/filters.py
+++ b/site/zenodo_rdm/filters.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# ZenodoRDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Filters to be used in the Jinja templates."""
+
+from invenio_records.dictutils import dict_lookup
+
+
+def is_blr_related_record(record):
+    """Check if we need to display related records for this record."""
+    valid_types = [
+        "Figure",
+        "Taxonomic treatment",
+        "Book chapter",
+        "Journal article",
+        "Drawing",
+    ]
+
+    try:
+        slug = dict_lookup(record, "expanded.parent.communities.default.slug")
+        resource_type = dict_lookup(record, "metadata.resource_type.title.en")
+        is_valid_type = resource_type in valid_types
+
+        if slug == "biosyslit" and is_valid_type:
+            return True
+
+        return False
+    except KeyError:
+        return False

--- a/site/zenodo_rdm/views.py
+++ b/site/zenodo_rdm/views.py
@@ -14,6 +14,7 @@ from invenio_records_resources.resources.records.utils import search_preference
 from marshmallow import ValidationError
 
 from .decorators import cached_unless_authenticated_or_flashes
+from .filters import is_blr_related_record
 from .support.support import ZenodoSupport
 
 
@@ -86,5 +87,8 @@ def create_blueprint(app):
     )
 
     app.register_error_handler(400, handle_validation_errors)
+
+    # Register template filters
+    blueprint.add_app_template_filter(is_blr_related_record)
 
     return blueprint

--- a/site/zenodo_rdm/webpack.py
+++ b/site/zenodo_rdm/webpack.py
@@ -23,6 +23,7 @@ theme = WebpackThemeBundle(
                 "zenodo-rdm-support": "./js/zenodo_rdm/src/support/support.js",
                 "zenodo-rdm-citations": "./js/zenodo_rdm/src/citations/index.js",
                 "zenodo-rdm-communities-carousel": "./js/zenodo_rdm/src/communities-carousel.js",
+                "zenodo-rdm-blr-search": "./js/zenodo_rdm/src/blr-related-works/index.js",
             },
             dependencies={
                 "@babel/runtime": "^7.9.0",

--- a/templates/semantic-ui/zenodo_rdm/records/detail.html
+++ b/templates/semantic-ui/zenodo_rdm/records/detail.html
@@ -64,6 +64,20 @@
 
 {# Additional details #}
 {%- block record_details -%}
+
+  {% if record.expanded.parent.communities.default.slug == "biosyslit" %}
+    {# BLR Related works #}
+    <section
+      id="blr-search"
+      class="rel-mt-2"
+      data-blr-endpoint="/api/records"
+      data-record-doi='{{ record.pids.doi.identifier | tojson }}'
+      data-resource-type='{{ record.metadata.resource_type.title.en | tojson }}'
+      data-communities='{{ record.expanded.parent.communities | tojson }}'
+    >
+    </section>
+  {% endif %}
+
   <section id="additional-details" class="rel-mt-2" aria-label="{{ _('Additional record details') }}">
     {%- include "zenodo_rdm/records/details/details.html" %}
   </section>
@@ -77,7 +91,8 @@
       id="citations-search"
       data-record-pids='{{ record.pids | tojson }}'
       data-record-parent-pids='{{ parent_pids | tojson }}'
-      data-citations-endpoint="{{config.ZENODO_RECORDS_UI_CITATIONS_ENDPOINT}}" aria-label="{{ _('Record citations')}}"
+      data-citations-endpoint="{{config.ZENODO_RECORDS_UI_CITATIONS_ENDPOINT}}"
+      aria-label="{{ _('Record citations')}}"
       class="rel-mb-1"
     >
     </section>
@@ -87,4 +102,8 @@
 {% block javascript %}
   {{super()}}
   {{ webpack['zenodo-rdm-citations.js'] }}
+
+  {% if record.expanded.parent.communities.default.slug == "biosyslit" %}
+    {{ webpack['zenodo-rdm-blr-search.js'] }}
+  {% endif %}
 {% endblock javascript %}

--- a/templates/semantic-ui/zenodo_rdm/records/detail.html
+++ b/templates/semantic-ui/zenodo_rdm/records/detail.html
@@ -9,6 +9,7 @@
 {%- extends "invenio_app_rdm/records/detail.html" %}
 
 {%- set citations_enabled = config.ZENODO_RECORDS_UI_CITATIONS_ENABLE %}
+{%- set isBlrRecord = record | is_blr_related_record %}
 
 {%- block record_files -%}
   {# record has files BUT passed files are empty. This happens when we display are request. #}
@@ -65,16 +66,28 @@
 {# Additional details #}
 {%- block record_details -%}
 
-  {% if record.expanded.parent.communities.default.slug == "biosyslit" %}
+  {% if isBlrRecord %}
     {# BLR Related works #}
+    <h2>Linked records</h2>
     <section
       id="blr-search"
-      class="rel-mt-2"
       data-blr-endpoint="/api/records"
       data-record-doi='{{ record.pids.doi.identifier | tojson }}'
       data-resource-type='{{ record.metadata.resource_type.title.en | tojson }}'
-      data-communities='{{ record.expanded.parent.communities | tojson }}'
+      data-blr-id='{{ record.expanded.parent.communities.default.id | tojson }}'
     >
+      <div class="ui segment">
+        <div class="ui fluid placeholder">
+          <div class="image header">
+            <div class="long line"></div>
+            <div class="line"></div>
+          </div>
+          <div class="image header">
+            <div class="long line"></div>
+            <div class="line"></div>
+          </div>
+        </div>
+      </div>
     </section>
   {% endif %}
 
@@ -103,7 +116,7 @@
   {{super()}}
   {{ webpack['zenodo-rdm-citations.js'] }}
 
-  {% if record.expanded.parent.communities.default.slug == "biosyslit" %}
+  {% if isBlrRecord %}
     {{ webpack['zenodo-rdm-blr-search.js'] }}
   {% endif %}
 {% endblock javascript %}


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/567

Needs https://github.com/inveniosoftware/react-searchkit/pull/260

**Edit:** After discussing with Lars, it was decided to remove the search bar for now, as there are issues related to having the initial query string (to show only related results for the specific record) + additional query strings added by the user. In order to add the search bar back, these are the known alternatives that will need a solution:
- if the query string is added to the state (`queryString`), the string shows up in the input field. The input field should be empty, but the query string needs to remain.
- if the query string is added directly to the endpoint url parameters, the search does not work, as there will be two `q` parameters once another search is performed.
- the query string cannot be set as a filter, as this requires the implementation of custom filters in the backend.

### Screenshots
<img width="766" alt="Screenshot 2023-12-13 at 8 23 23 AM" src="https://github.com/zenodo/zenodo-rdm/assets/21052053/d04c9493-56f1-4811-8189-4fa5533ae3b3">
<img width="776" alt="Screenshot 2023-12-13 at 8 23 33 AM" src="https://github.com/zenodo/zenodo-rdm/assets/21052053/9a55fbb2-94ef-482c-a295-fbe9fd043895">
<img width="878" alt="Screenshot 2023-12-13 at 8 26 09 AM" src="https://github.com/zenodo/zenodo-rdm/assets/21052053/df1401fe-6d0a-4e4e-8ddc-5058f262d292">

