### PR TITLE
records: fix citations not showing for ext DOIs

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/records/detail.html
+++ b/templates/semantic-ui/zenodo_rdm/records/detail.html
@@ -75,7 +75,7 @@
     <section
       id="citations-search"
       data-record-pids='{{ record.pids | tojson }}'
-      data-record-parent-pids='{{ record.parent.pids | tojson }}'
+      data-record-parent-pids='{{ record.parent.pids or record.pids | tojson }}'
       data-citations-endpoint="{{config.ZENODO_RECORDS_UI_CITATIONS_ENDPOINT}}" aria-label="{{ _('Record citations')}}"
       class="rel-mb-1"
     >


### PR DESCRIPTION
* Fixes an issue with citations not rendering for external DOIs because the record doesn't have a parent record pid.

Closes zenodo/rdm-project#607