### PR TITLE
citations: fixed html rendering.

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/records/detail.html
+++ b/templates/semantic-ui/zenodo_rdm/records/detail.html
@@ -72,10 +72,11 @@
 
 {%- block record_footer -%}
   {% if citations_enabled and not is_preview %}
+    {% set parent_pids = record.parent.pids or record.pids %}
     <section
       id="citations-search"
       data-record-pids='{{ record.pids | tojson }}'
-      data-record-parent-pids='{{ record.parent.pids or record.pids | tojson }}'
+      data-record-parent-pids='{{ parent_pids | tojson }}'
       data-citations-endpoint="{{config.ZENODO_RECORDS_UI_CITATIONS_ENDPOINT}}" aria-label="{{ _('Record citations')}}"
       class="rel-mb-1"
     >


### PR DESCRIPTION
Citations box is not rendering, throws an exception in the console due to malformed JSON. 


![image](https://github.com/zenodo/zenodo-rdm/assets/21204744/7ce64bad-4e1a-4dc7-9ca6-ac176d814dbe)

Which in turns points to:  https://github.com/zenodo/zenodo-rdm/blob/master/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/citations/index.js#L36