### PR TITLE
queryparser: fix doi and communities field search

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -25,6 +25,7 @@ from invenio_i18n import lazy_gettext as _
 from invenio_oauthclient.contrib.keycloak import KeycloakSettingsHelper
 from invenio_oauthclient.contrib.orcid import ORCIDOAuthSettingsHelper
 from invenio_github.oauth.remote_app import github_app as github_remote_app
+from invenio_records_resources.services.records.queryparser import FieldValueMapper
 from invenio_rdm_records.config import (
     RDM_SORT_OPTIONS as BASE_SORT_OPTIONS,
     RDM_FACETS,
@@ -54,6 +55,7 @@ from zenodo_rdm import facets as zenodo_community_facets
 from zenodo_rdm.metrics.config import METRICS_CACHE_UPDATE_INTERVAL
 from zenodo_rdm.openaire.records.components import OpenAIREComponent
 from zenodo_rdm.github.schemas import CitationMetadataSchema
+from zenodo_rdm.queryparser import word_doi, word_communities
 
 # Flask
 # =====
@@ -263,8 +265,8 @@ ZENODO_LEGACY_SEARCH_MAP = {
     "access_right": "access.status",
     "alternate.identifier": "metadata.identifiers.identifier",
     "alternate.scheme": "metadata.identifiers.scheme",
-    "communities": "parent.communities.ids",
-    "conceptdoi": "parent.pids.doi.identifier",
+    "communities": FieldValueMapper("parent.communities.ids", word=word_communities),
+    "conceptdoi": FieldValueMapper("parent.pids.doi.identifier", word=word_doi),
     "conceptrecid": "parent.id",
     "created": "created",
     # Creators
@@ -279,7 +281,7 @@ ZENODO_LEGACY_SEARCH_MAP = {
     "contributors.gnd": "metadata.contributors.person_or_org.identifiers.identifier",
     "contributors.type": "metadata.contributors.role.id",
     "description": "metadata.description",
-    "doi": "pids.doi.identifier",
+    "doi": FieldValueMapper("pids.doi.identifier", word=word_doi),
     "embargodate": "access.embargo.until",
     "grants.code": "metadata.funding.award.number",
     "grants.acronym": "metadata.funding.award.acronym",
@@ -288,7 +290,7 @@ ZENODO_LEGACY_SEARCH_MAP = {
     # owner
     "owners": "parent.access.owned_by.user",
     # TODO: Add `grants.funder.*` mappings
-    "grants.funder.doi": "metadata.funding.funder.identifiers.identifier",
+    "grants.funder.doi": FieldValueMapper("metadata.funding.funder.identifiers.identifier", word=word_doi),
     "grants.funder.name": "metadata.funding.funder.name",
     "keywords": "metadata.subjects.subject",
     "language": "metadata.languages.id",
@@ -330,9 +332,12 @@ ZENODO_LEGACY_SEARCH_MAP = {
     "filecount": "files.count",
     "filename": "files.entries.key",
     "filetype": "files.types",
+    "filesize": "files.totalbytes",
     "size": "files.totalbytes",
     "_files.checksum": "files.entries.checksum",
     "_files.size": "files.entries.size",
+    # New mappings
+    "user": "parent.access.owned_by.user",
 }
 
 LEGACY_SORT_OPTIONS = {

--- a/site/zenodo_rdm/queryparser.py
+++ b/site/zenodo_rdm/queryparser.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Zenodo is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Query parsers."""
+
+from invenio_communities.communities.records.models import CommunityMetadata
+from invenio_db import db
+from luqum.tree import Phrase
+
+
+def word_doi(node):
+    """Quote DOIs."""
+    if not node.value.startswith("10."):
+        return node
+    return Phrase(f'"{node.value}"')
+
+
+def word_communities(node):
+    """Resolve community slugs to IDs."""
+    slug = node.value
+    uuid = (
+        db.session.query(CommunityMetadata.id)
+        .filter(CommunityMetadata.slug == slug)
+        .scalar()
+    )
+    return Phrase(f'"{uuid}"')


### PR DESCRIPTION
Fixes searchers such as:

```
doi:10.5281/zenodo.12345
communities:biosyslit
user:176
```

Depends on https://github.com/inveniosoftware/invenio-records-resources/pull/557