### PR TITLE
global: updated robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -8,4 +8,5 @@ Disallow: /me
 Disallow: /login
 Disallow: /logout
 Disallow: /records/*/preview
+Allow: /api/records/*/files
 Crawl-delay: 10


### PR DESCRIPTION
closes https://github.com/zenodo/ops/issues/358

 * added rule to allow crawling of /api/files