### PR TITLE
files: added x509 authentication to EOS offload.

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -712,6 +712,14 @@ FILES_REST_XSENDFILE_ENABLED = False
 ZENODO_EOS_OFFLOAD_ENABLED = False
 ZENODO_EOS_OFFLOAD_HTTPHOST = ""
 ZENODO_EOS_OFFLOAD_REDIRECT_BASE_PATH = ""
+# control EOS offload authentication
+ZENODO_EOS_OFFLOAD_AUTH_X509 = False
+"""Specifies whether to use X509 authentication for EOS offload."""
+ZENODO_EOS_OFFLOAD_X509_CERT_PATH = ""
+"""The path to the X509 certificate file."""
+ZENODO_EOS_OFFLOAD_X509_KEY_PATH = ""
+"""The path to the X509 private key file."""
+
 
 FILES_REST_DEFAULT_QUOTA_SIZE = 5*10**10
 FILES_REST_DEFAULT_MAX_FILE_SIZE = 5*10**10


### PR DESCRIPTION
closes https://github.com/zenodo/ops/issues/322

I added [docs](https://digital-repositories.web.cern.ch/zenodo/support/operations/#eos-x509-certificate-replacement) on how to replace the certificate.

This was tested in `zenodo-rdm-qa`, inside a pod. I added the configmap to the `worker` deployment and mounted the certificates. The test was run in an `invenio shell`, using a `requests.Session.get` request to retrieve a file from eosmedia and it worked.

# Deployment

⚠️ even though the changes are behind a configuration, please align with me before this is deployed

In Openshift, set the following variables (we need to create the deployment config first `INVENIO_ZENODO_EOS_*` so they are added to the application):

```python
INVENIO_ZENODO_EOS_OFFLOAD_AUTH_X509 = True 
INVENIO_ZENODO_EOS_OFFLOAD_X509_CERT_PATH = "/etc/certificates/cert.pem"
INVENIO_ZENODO_EOS_OFFLOAD_X509_KEY_PATH = "/etc/certificates/key.pem"
INVENIO_ZENODO_EOS_OFFLOAD_HTTPHOST = "https://eosmedia.cern.ch:8444"
```

 To create the config map and the volume in openshift:

```shell
# Create configmap
oc create configmap service-certificates --from-literal=key.pem=""  --from-literal=cert.pem=""

# Create volume in "worker" and "web" deployments
oc set volume deployment/worker --add  --name=service-certificates --type=configmap  --mount-path=/etc/certificates  --configmap-name=service-certificates
oc set volume deployment/web --add  --name=service-certificates --type=configmap  --mount-path=/etc/certificates  --configmap-name=service-certificates
````

Then add the certificate and key as detailed [here](https://digital-repositories.web.cern.ch/zenodo/support/operations/#eos-x509-certificate-replacement)

