### PR TITLE
recent uploads: updated label colors and styling

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/macros/record_item.html
+++ b/templates/semantic-ui/zenodo_rdm/macros/record_item.html
@@ -31,8 +31,8 @@
 
       {# Top labels #}
       <div class="extra labels-actions">
-        <div class="ui small horizontal primary label">
-          {{ record.ui.publication_date_l10n_long }} ({{ record.ui.version }})
+        <div class="ui small horizontal theme-primary label">
+          <p>{{ record.ui.publication_date_l10n_long }} ({{ record.ui.version }})</p>
         </div>
         <div class="ui small horizontal neutral label">
           {{ record.ui.resource_type.title_l10n }}
@@ -49,7 +49,7 @@
       </div>
 
       {# Title #}
-      <div class="header">
+      <div class="header theme-primary-text">
         <a href="/records/{{ record.id }}">{{ record.metadata.title }}</a>
       </div>
 

--- a/templates/semantic-ui/zenodo_rdm/macros/record_item.html
+++ b/templates/semantic-ui/zenodo_rdm/macros/record_item.html
@@ -31,7 +31,7 @@
 
       {# Top labels #}
       <div class="extra labels-actions">
-        <div class="ui small horizontal theme-primary label">
+        <div class="ui small horizontal primary theme-primary label">
           <p>{{ record.ui.publication_date_l10n_long }} ({{ record.ui.version }})</p>
         </div>
         <div class="ui small horizontal neutral label">

--- a/templates/themes/horizon/invenio_communities/details/home/index.html
+++ b/templates/themes/horizon/invenio_communities/details/home/index.html
@@ -49,16 +49,20 @@
     </div>
 
     {% if records %}
-      <div class="ui container">
-        <h2>{{ _("Recent uploads") }}</h2>
-        <div class="ui divider"></div>
+      <div class="ui stackable theme-font grid container ">
+        <div class="column rel-mb-4">
+          <div class="row item">
+            <h1 class="ui large header">{{ title }}</h1>
+          </div>
+          <div class="ui divider"></div>
 
-        <div class="ui fluid stackable three column grid">
-          {% for record in records %}
-            <ul class="ui column items m-0">
-              {{ record_item(record=record) }}
-            </ul>
-          {% endfor %}
+          <div class="ui fluid stackable three column grid">
+            {% for record in records %}
+              <ul class="ui column items m-0">
+                {{ record_item(record=record) }}
+              </ul>
+            {% endfor %}
+          </div>
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION

Closes Issue [#719](https://github.com/zenodo/zenodo-rdm/issues/719)

- frontpage: label colouring should follow the EC theme

<img width="1792" alt="Screenshot 2024-02-13 at 20 40 07" src="https://github.com/zenodo/zenodo-rdm/assets/51617644/1fcd94b4-2bd3-4e32-8999-084773a6c141">
