### PR TITLE
frontpage: display verified community logo

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/macros/communities_list.html
+++ b/templates/semantic-ui/zenodo_rdm/macros/communities_list.html
@@ -22,16 +22,18 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 -#}
 
-{% macro communities_list(communities=None) %}
+{% macro communities_list(communities=None, branded=None) %}
   {% for community in communities %}
     {% set community_title = community.metadata.get("title", "No title") if community.metadata %}
-    <span class="display-inline-flex comma-separated">
-      <a
-        href="/communities/{{ community.slug }}"
-        title="{{ community_title }}: {{_('Search')}}"
-      >
-        {{ community_title }}
-      </a>
-    </span>
+    {% if not (community.id == branded and community.theme) %}
+      <span class="display-inline-flex comma-separated">
+        <a
+          href="/communities/{{ community.slug }}"
+          title="{{ community_title }}: {{_('Search')}}"
+        >
+          {{ community_title }}
+        </a>
+      </span>
+    {% endif %}
   {% endfor%}
 {% endmacro %}

--- a/templates/semantic-ui/zenodo_rdm/macros/record_item.html
+++ b/templates/semantic-ui/zenodo_rdm/macros/record_item.html
@@ -25,7 +25,7 @@
 {% from "zenodo_rdm/macros/creators.html" import creators %}
 {% from "zenodo_rdm/macros/communities_list.html" import communities_list %}
 
-{% macro record_item(record=None) %}
+{% macro record_item(record=None, highlightCommunity=True) %}
   <li class="item">
     <div class="content">
 
@@ -46,7 +46,7 @@
             <i class="icon {{ access_status_icon }}" aria-hidden="true"></i>
             {{ access_status }}
         </div>
-      </div>
+    </div>
 
       {# Title #}
       <div class="header theme-primary-text">
@@ -68,12 +68,6 @@
         {{ description | truncate(length=350, end='...') }}
       </p>
 
-      {# Communities list #}
-      <h5>
-        {% set communities_entries = record.parent.communities.entries %}
-        <b>{{ _("Part of:")}} {{ communities_list(communities=communities_entries) }}</b>
-      </h5>
-
       <div class="extra">
         <div class="flex justify-space-between align-items-end">
           {# Publishing details #}
@@ -84,6 +78,16 @@
               <small>
                 {% if created_date %}
                   {{ _("Uploaded on")}} {{ created_date }}
+                {% endif %}
+              </small>
+            </p>
+
+            {# Communities list #}
+            <p>
+              <small>
+                {% set communities_entries = record.parent.communities.entries %}
+                {% if communities_entries %}
+                  <b>{{ _("Part of")}} {{ communities_list(communities=communities_entries, branded=record.parent.communities.default) }}</b>
                 {% endif %}
               </small>
             </p>
@@ -134,6 +138,25 @@
             {% endif %}
           </small>
         </div>
+        {% if highlightCommunity %}
+          {% set communities = record.parent.communities.entries %}
+          {% set branded_community_id = record.parent.communities.default %}
+
+          {% if communities and branded_community_id %}
+            {% for community in communities %}
+              {% if community.id == branded_community_id and community.theme %}
+                {% set primaryColor = community.theme.get('style').get('primaryColor') %}
+                <a href="/communities/{{ branded_community_id }}"
+                   class="ui label themed-community-label"
+                   style="background-color: {{ primaryColor }};"
+                >
+                  {{ community.metadata.title }}
+                  <img src="/api/communities/{{ branded_community_id }}/logo" alt class="ui image themed-community-logo right-floated">
+                </a>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endif %}
       </div>
     </div>
   </li>

--- a/templates/themes/horizon/invenio_communities/details/home/index.html
+++ b/templates/themes/horizon/invenio_communities/details/home/index.html
@@ -59,7 +59,7 @@
           <div class="ui fluid stackable three column grid">
             {% for record in records %}
               <ul class="ui column items m-0">
-                {{ record_item(record=record) }}
+                {{ record_item(record=record, highlightCommunity=False) }}
               </ul>
             {% endfor %}
           </div>


### PR DESCRIPTION
* closes https://github.com/zenodo/zenodo-rdm/issues/716

Also moved "Part of" to the small bottom information

Frontpage:
![Screenshot 2024-02-27 at 11 23 03](https://github.com/zenodo/zenodo-rdm/assets/61321254/23fdbc28-3096-4131-8932-f6ecb0a105d0)

Don't highlight community logo in the community front page:
![Screenshot 2024-02-27 at 11 24 02](https://github.com/zenodo/zenodo-rdm/assets/61321254/218ac8ef-eacd-4dcc-86cb-e4423d8a7617)


