### PR TITLE
footer: added themed site_footer

### DIFF
--- a/templates/themes/horizon/invenio_app_rdm/site_footer.html
+++ b/templates/themes/horizon/invenio_app_rdm/site_footer.html
@@ -1,0 +1,48 @@
+{#
+    -*- coding: utf-8 -*-
+    Copyright (C) 2023-2024 CERN.
+
+    Invenio App RDM is free software; you can redistribute it and/or modify it
+    under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+<div class="footer-bottom sub-footer theme-default rel-p-1">
+  <div class="ui container">
+    <div class="ui grid">
+      {%- block footer_bottom_left %}
+        <div
+        class="four wide computer six wide tablet sixteen wide mobile column left middle aligned"
+        >
+        {% trans cern_data_centre="http://information-technology.web.cern.ch/about/computer-centre" %}Powered by
+          <a href="{{ cern_data_centre }}">CERN Data Centre</a>
+        {% endtrans %}
+        </div>
+      {%- endblock footer_bottom_left %}
+
+      <div
+        class="four wide computer four wide tablet sixteen wide mobile column centered middle aligned"
+      >
+        {% trans %}
+          <i class="green check circle outline icon"></i>
+            Verified community
+        {% endtrans %}
+      </div>
+      <div
+        class="four wide computer six wide tablet sixteen wide mobile column right aligned"
+      >
+        {%- block footer_bottom_right %}
+          <div class="ui horizontal list">
+            <div class="item">{{ _('Status') }}</div>
+            <div class="item">{{ _('Privacy policy') }}</div>
+            <div class="item">{{ _('Terms of use') }}</div>
+            <div class="item">{{ _('Support') }}</div>
+          </div>
+          {%- if config.I18N_LANGUAGES %} {% from
+        "invenio_i18n/macros/language_selector.html" import language_selector_dropdown %}
+            {{ language_selector_dropdown() }}
+          {%- endif %}
+        {%- endblock footer_bottom_right %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/themes/horizon/invenio_app_rdm/site_footer.html
+++ b/templates/themes/horizon/invenio_app_rdm/site_footer.html
@@ -13,9 +13,10 @@
         <div
         class="four wide computer six wide tablet sixteen wide mobile column left middle aligned"
         >
-        {% trans cern_data_centre="http://information-technology.web.cern.ch/about/computer-centre" %}Powered by
-          <a href="{{ cern_data_centre }}">CERN Data Centre</a>
-        {% endtrans %}
+          {% trans %}
+            Powered by
+            <a href="http://information-technology.web.cern.ch/about/computer-centre">CERN Data Centre</a> & <a href="https://inveniordm.docs.cern.ch/">InvenioRDM</a>
+          {% endtrans %}
         </div>
       {%- endblock footer_bottom_left %}
 


### PR DESCRIPTION
Added site_footer for customization specific to Zenodo https://github.com/inveniosoftware/invenio-app-rdm/pull/2578#discussion_r1494826801

- powered by InvenioRDM -> powered by CERN Data Center (current zenodo one)

<img width="1590" alt="Screenshot 2024-02-21 at 16 08 51" src="https://github.com/zenodo/zenodo-rdm/assets/51617644/244f879a-71f6-409d-8daa-c0df36808299">

