### PR TITLE
 Frontpage: header logo link and footer text change

### DIFF
--- a/templates/themes/horizon/invenio_app_rdm/footer.html
+++ b/templates/themes/horizon/invenio_app_rdm/footer.html
@@ -16,7 +16,7 @@
               class="rdm-footer five wide tablet three wide computer sixteen wide mobile column rel-mb-2">
               <h2 class="ui small header">{{ _("Managed by") }}</h2>
               {% trans ec_open_research="https://open-research-europe.ec.europa.eu/" %}
-                <a href="{{ ec_open_research }}">CERN on behalf of European Commission (Directorate-General for Research and Innovation)</a>
+                <a href="{{ ec_open_research }}">CERN on behalf of the European Commission</a>
                 <i class="green check circle outline icon"></i>
               {% endtrans %}
             </div>

--- a/templates/themes/horizon/invenio_communities/details/header.html
+++ b/templates/themes/horizon/invenio_communities/details/header.html
@@ -21,11 +21,13 @@ under the terms of the MIT License; see LICENSE file for more details.
                   class="community-header flex align-items-center column-mobile align-items-start-mobile">
             <div class="flex align-items-center">
               <div class="ui rounded image community-image mt-5 rel-mr-2">
-                <img
-                        src="{{ community.links.logo | resolve_community_logo(community.id) }}"
-                        alt=""
-                        class="rel-mb-1"
-                />
+                <a href="{{ community.links.self_html }}">
+                  <img
+                          src="{{ community.links.logo | resolve_community_logo(community.id) }}"
+                          alt=""
+                          class="rel-mb-1"
+                  />
+                </a>
               </div>
 
               <div class="mobile only">

--- a/templates/themes/horizon/invenio_communities/details/home/index.html
+++ b/templates/themes/horizon/invenio_communities/details/home/index.html
@@ -195,7 +195,7 @@
                         <strong>{{ _("Pilot") }}</strong> — {{ _("EU Open Research Repository is in a pilot phase and expected to be fully operational in autumn 2024.") }}
                       </li>
                       <li>
-                        <strong>{{ _("European Commission & CERN") }}</strong> — {{ _("the EU Open Research Community is managed by CERN on behalf of the European Commission (Directorate-General for Research and Innovation).") }}
+                        <strong>{{ _("European Commission & CERN") }}</strong> — {{ _("the EU Open Research Community is managed by CERN on behalf of the European Commission.") }}
                       </li>
                       <li>
                         <strong>{{ _("Become an early adopter") }}</strong> — {{ _("every upload is assigned a Digital Object Identifier (DOI), to make them citable and trackable.") }}


### PR DESCRIPTION
Fixes #786

* The logo is now also linking to the community (not only the text next to the logo).
* Modified the text related to the EU (and add a missing "the").