### PR TITLE
support: fix user creation set unique login

### DIFF
--- a/site/zenodo_rdm/support/support.py
+++ b/site/zenodo_rdm/support/support.py
@@ -141,6 +141,7 @@ class ZenodoSupport(MethodView):
         """Create a customer."""
         params = {
             "email": email,
+            "login": email,
             "roles": ["Customer"],
         }
         if name:


### PR DESCRIPTION
Fixes: https://github.com/zenodo/ops/issues/389

Creating users in Zammad fails with the error "This object already exists.".
There's a unique constraint on the `login` column, and we do not set the `login` when creating users.
This pull requests sets the `login` to the same value as the `email`, as is the case of the already created users.
