### PR TITLE
ui: prevent checksum popup overflowing on mobile

### DIFF
--- a/assets/less/zenodo-rdm/modules/popup.overrides
+++ b/assets/less/zenodo-rdm/modules/popup.overrides
@@ -42,3 +42,9 @@
     }
   }
 }
+
+[data-tooltip]::after {
+  width: max-content;
+  max-width: 80vw;
+  white-space: break-spaces;
+}


### PR DESCRIPTION
Close https://github.com/zenodo/ops/issues/341

Problem:

![image](https://github.com/zenodo/zenodo-rdm/assets/6676843/25599a96-c8dd-412b-8cd2-06df3d6ffc2a)

After: 

![image](https://github.com/zenodo/zenodo-rdm/assets/6676843/57bf0e19-4562-46d5-ba4f-4d256c1d0b09)

And preserves how it looks with wide viewports 

![image](https://github.com/zenodo/zenodo-rdm/assets/6676843/6ba0b5e6-06d7-4c0f-9292-62f52fd114b6)
