### PR TITLE
config: remove duplicate code from invenio.cfg

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -672,19 +672,7 @@ METRICS_UPTIME_ROBOT_METRIC_IDS = {}
 METRICS_UPTIME_ROBOT_URL = "https://api.uptimerobot.com/v2/getMonitors"
 METRICS_UPTIME_ROBOT_API_KEY = None
 
-# OpenAIRE configs
-OPENAIRE_API_URL = "http://dev.openaire.research-infrastructures.eu/is/mvc/api/results"
-"""OpenAIRE API endpoint."""
-
-# Beta configs
-OPENAIRE_API_URL_BETA = None
-
 # Other configs
-OPENAIRE_PORTAL_URL = "https://explore.openaire.eu"
-"""OpenAIRE portal url."""
-
-OPENAIRE_DIRECT_INDEXING_ENABLED = True
-"""Enable sending published records for direct indexing at OpenAIRE."""
 
 RDM_RECORDS_SERVICE_COMPONENTS = DefaultRecordsComponents + [OpenAIREComponent, SignalComponent]
 """Addd OpenAIRE component to records service."""


### PR DESCRIPTION
The removed lines from `invenio.cfg` in this commit are the same as and override the lines in https://github.com/zenodo/zenodo-rdm/blob/43c4d5995417cda205d65d21671dc24c12920240/site/zenodo_rdm/openaire/config.py. @slint has already prevented this change affecting prod

related to https://github.com/inveniosoftware/invenio-rdm-records/pull/1699#issuecomment-2017771501