### PR TITLE
permissions: fixed files modification permissions for external DOIs

### DIFF
--- a/site/zenodo_rdm/permissions.py
+++ b/site/zenodo_rdm/permissions.py
@@ -257,7 +257,7 @@ class ZenodoRDMRecordPermissionPolicy(RDMRecordPermissionPolicy):
         Administration(),
         UserManager,
         SystemProcess(),
-        IfExternalDOIRecord(then_=[ExternalDOIFilesManager()], else_=[Disable()]),
+        IfExternalDOIRecord(then_=[ExternalDOIFilesManager()], else_=[]),
     ]
 
 


### PR DESCRIPTION
Currently, admins can't modify files due to a bug with permissions. 