### PR TITLE
scripts: added custom worker beat to deployments.

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -17,6 +17,7 @@ DEPLOYMENTS = {
     "worker-low": ["worker-low"],
     "worker-beat": ["worker-beat"],
     "terminal": ["terminal"],
+    "worker-beat-custom": ["worker-beat-custom"],
 }
 deployment_names = ", ".join(DEPLOYMENTS.keys())
 


### PR DESCRIPTION
Since we added a new deployment, we have to update its version when we release. 

If we move the scheduler to a container inside the existing beat, we don't need this PR.