### PR TITLE
mirador: set default sidebar state to closed

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -880,7 +880,7 @@ MIRADOR_PREVIEW_CONFIG = {
         "defaultView": "single",
         "hideWindowTitle": True,
         "highlightAllAnnotations": True,
-        "sideBarOpen": True,
+        "sideBarOpen": False,
         "switchCanvasOnSearch": False,
         "panels": {
             "info": True,

--- a/site/zenodo_rdm/previewer/mirador.py
+++ b/site/zenodo_rdm/previewer/mirador.py
@@ -70,6 +70,7 @@ def preview(file):
         tpl_ctx["annotations"] = annotations
 
         tpl_ctx["mirador_cfg"]["window"]["panels"]["annotations"] = bool(annotations)
+        tpl_ctx["mirador_cfg"]["window"]["sideBarOpen"] = bool(annotations)
         tpl_ctx["mirador_cfg"]["window"]["sideBarPanel"] = (
             "annotations" if annotations else "info"
         )


### PR DESCRIPTION
Closes Issue: https://github.com/zenodo/zenodo-rdm/issues/894