### PR TITLE
openaire: fixed delete task

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -195,6 +195,7 @@ CELERY_TASK_ROUTES = {
     "invenio_files_rest.tasks.verify_checksum": {"queue": "low"},
     "invenio_rdm_records.services.iiif.tasks.generate_tiles": {"queue": "low"},
     "invenio_records_resources.tasks.extract_file_metadata": {"queue": "low"},
+    "invenio_users_resources.services.users.tasks.execute_moderation_actions": {"queue": "low"},
 }
 
 # Flask-Babel

--- a/site/tests/openaire/test_components.py
+++ b/site/tests/openaire/test_components.py
@@ -83,7 +83,7 @@ def test_on_delete(
 
     mocked_session.delete.assert_called_once_with(
         openaire_api_endpoint,
-        json={
+        params={
             "originalId": f"10.5281/zenodo.{recid}",
             "collectedFromId": "opendoar____::2659",
         },
@@ -131,7 +131,7 @@ def test_on_restore(
     delete_calls = [
         call(
             openaire_api_endpoint,
-            json={
+            params={
                 "originalId": f"10.5281/zenodo.{recid}",
                 "collectedFromId": "opendoar____::2659",
             },

--- a/site/tests/openaire/test_tasks.py
+++ b/site/tests/openaire/test_tasks.py
@@ -145,7 +145,7 @@ def test_openaire_delete_task(
     openaire_url = running_app.app.config["OPENAIRE_API_URL"]
     params = {"originalId": original_id, "collectedFromId": datasource_id}
 
-    mocked_session.delete.assert_called_once_with(openaire_url, json=params)
+    mocked_session.delete.assert_called_once_with(openaire_url, params=params)
 
     # Assert key is not in cache : means success
     assert not current_cache.cache.has(f"openaire_direct_index:{openaire_record.id}")

--- a/site/zenodo_rdm/openaire/tasks.py
+++ b/site/zenodo_rdm/openaire/tasks.py
@@ -118,14 +118,14 @@ def openaire_delete(record_id=None, retry=True):
 
         params = {"originalId": original_id, "collectedFromId": datasource_id}
         req = openaire_request_factory()
-        res = req.delete(current_app.config["OPENAIRE_API_URL"], json=params)
+        res = req.delete(current_app.config["OPENAIRE_API_URL"], params=params)
 
         if not res.ok:
             raise OpenAIRERequestError(res.text)
 
         if current_app.config["OPENAIRE_API_URL_BETA"]:
             res_beta = req.delete(
-                current_app.config["OPENAIRE_API_URL_BETA"], json=params
+                current_app.config["OPENAIRE_API_URL_BETA"], params=params
             )
 
             if not res_beta.ok:
@@ -157,7 +157,7 @@ def retry_openaire_failures():
     for key in failed_records:
         try:
             record_id = key.decode().split("openaire_direct_index:")[1]
-            record = records_service.read(system_identity, record_id)
+            record = records_service.read(system_identity, record_id, include_deleted=True)
             is_deleted = record.data["deletion_status"]["is_deleted"]
 
             # If record was deleted, try to remove it from OpenAIRE

--- a/site/zenodo_rdm/openaire/tasks.py
+++ b/site/zenodo_rdm/openaire/tasks.py
@@ -157,7 +157,9 @@ def retry_openaire_failures():
     for key in failed_records:
         try:
             record_id = key.decode().split("openaire_direct_index:")[1]
-            record = records_service.read(system_identity, record_id, include_deleted=True)
+            record = records_service.read(
+                system_identity, record_id, include_deleted=True
+            )
             is_deleted = record.data["deletion_status"]["is_deleted"]
 
             # If record was deleted, try to remove it from OpenAIRE

--- a/site/zenodo_rdm/subcommunities/schema.py
+++ b/site/zenodo_rdm/subcommunities/schema.py
@@ -12,6 +12,8 @@ from marshmallow import Schema, ValidationError, fields, validates
 
 
 class SubCommunityRequestPayloadShema(Schema):
+    """Schema for the payload of a subcommunity request."""
+
     project_id = fields.String()
 
     @validates("project_id")


### PR DESCRIPTION
Request to retry failures is malformed, the `originalID` is expected as a string parameter and not in the request body


1. fixed request to delete from openaire
2. when retrying records, fixed record resolving for deleted records
3. moved `execute_moderation_actions` task to low priority queue