### PR TITLE
preview: updated pdf redirect based on metadata

### DIFF
--- a/site/zenodo_rdm/config.py
+++ b/site/zenodo_rdm/config.py
@@ -371,3 +371,26 @@ THEME_MATHJAX_CDN = (
     "//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"
     "?config=TeX-AMS-MML_HTMLorMML"
 )
+
+ANNOSTOR_COMMUNITIES = {
+    "biosyslit": {
+        "annostor_instance": "https://blr.annostor.org/",
+        "repo_instance": "zenodo",
+        "task": "taxons",
+    },
+    "hasdai": {
+        "annostor_instance": "https://hasdai.annostor.org/",
+        "repo_instance": "zenodo",
+        "task": "taxons",
+    },
+    "hasdai-sandboxy": {
+        "annostor_instance": "https://hasdai-sandboxy.annostor.org/",
+        "repo_instance": "zenodo_sandbox",
+        "task": "taxons",
+    },
+    "mfn": {
+        "annostor_instance": "https://mfn.annostor.org/",
+        "repo_instance": "zenodo_sandbox",
+        "task": "taxons",
+    },
+}

--- a/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -62,7 +62,7 @@
 
 
 {%- macro file_list(
-    files, pid, is_preview, include_deleted,
+    files, pid, is_preview, include_deleted, permissions,
     record=None,
     with_preview=true,
     download_endpoint='invenio_app_rdm_records.record_file_download',
@@ -117,6 +117,18 @@
           <td>{{ file.size|filesizeformat(binary=binary_sizes) }}</td>
           <td class="right aligned">
             <span>
+              {%- for community in record.parent.communities.entries -%}
+                {%- set slug = community.slug %}
+                {%- set annostor_config = config.ANNOSTOR_COMMUNITIES[slug] if slug in config.ANNOSTOR_COMMUNITIES else None -%}
+                {%- if annostor_config is not none -%}
+                  {%- set annostar_url = annostor_config.annostor_instance ~ "annotate/" ~ annostor_config.repo_instance ~ "/" ~ annostor_config.task ~ "/" ~ record.id  -%}
+                  {%- if permissions.can_edit and file_type=="pdf" and file.metadata.preview -%}
+                  <a role="button" class="ui compact mini button" href="{{ annostar_url }}">
+                    <i class="pencil icon" aria-hidden="true"></i>{{_("Annotate")}}<i aria-hidden="true" class="right aligned external icon"></i>
+                  </a>
+                  {%- endif -%}
+              {% endif %}
+              {%- endfor -%}
               {% if with_preview and file_type|lower is previewable %}
                 <a role="button" class="ui compact mini button preview-link" href="{{ file_url_preview }}" target="preview-iframe" data-file-key="{{file.key}}">
                   <i class="eye icon" aria-hidden="true"></i>{{_("Preview")}}
@@ -135,7 +147,7 @@
 {%- endmacro %}
 
 
-{% macro file_list_box(files, pid, is_preview, include_deleted, record) %}
+{% macro file_list_box(files, pid, is_preview, include_deleted, permissions, record) %}
   {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
   <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}" href="#files-list-accordion-panel">
     <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
@@ -158,7 +170,7 @@
         </div>
       {% endif %}
       <div>
-        {{ file_list(files, pid, is_preview, include_deleted, record=record, download_endpoint="invenio_app_rdm_records.record_file_download") }}
+        {{ file_list(files, pid, is_preview, include_deleted, permissions, record=record, download_endpoint="invenio_app_rdm_records.record_file_download") }}
       </div>
     </div>
   </div>

--- a/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -1,0 +1,195 @@
+{#
+  Copyright (C) 2020-2024 CERN.
+  Copyright (C) 2023 Northwestern University.
+  Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 TU Wien.
+  Copyright (C) New York University.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+
+{%- macro preview_file(preview_endpoint, pid_value, filename, is_preview, include_deleted, id='preview-iframe' ) %}
+  {%- set include_deleted_value = 0 -%}
+  {% if include_deleted %}
+    {%- set include_deleted_value = 1 -%}
+  {% endif %}
+  {% if is_preview %}
+    {%- set preview_url = url_for(preview_endpoint, pid_value=pid_value, filename=filename, preview=1, include_deleted=include_deleted_value) -%}
+  {% else %}
+    {%- set preview_url = url_for(preview_endpoint, pid_value=pid_value, filename=filename, include_deleted=include_deleted_value) -%}
+  {% endif %}
+  <iframe
+    title="{{_('Preview')}}"
+    class="preview-iframe"
+    id="{{id}}"
+    name="{{id}}"
+    src="{{ preview_url }}"
+  >
+  </iframe>
+{%- endmacro %}
+
+
+{% macro preview_file_box(file, pid, is_preview, record, include_deleted) %}
+  <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" href="#files-preview-accordion-panel">
+    <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
+      <div
+        role="button"
+        id="files-preview-accordion-trigger"
+        aria-controls="files-preview-accordion-panel"
+        aria-expanded="true"
+        tabindex="0"
+        class="trigger"
+        aria-label="{{ _('File preview') }}"
+      >
+        <span id="preview-file-title">{{ file.key }}</span>
+        <i class="angle right icon" aria-hidden="true"></i>
+      </div>
+    </h3>
+    <div
+      role="region"
+      id="files-preview-accordion-panel"
+      aria-labelledby="files-preview-accordion-trigger"
+      class="active content preview-container pt-0 {{record.ui.access_status.id}}"
+    >
+      <div>
+        {{ preview_file('invenio_app_rdm_records.record_file_preview', pid_value=pid, filename=file.key, is_preview=is_preview, include_deleted=include_deleted) }}
+      </div>
+    </div>
+  </div>
+{%- endmacro %}
+
+
+{%- macro file_list(
+    files, pid, is_preview, include_deleted,
+    record=None,
+    with_preview=true,
+    download_endpoint='invenio_app_rdm_records.record_file_download',
+    preview_endpoint='invenio_app_rdm_records.record_file_preview',
+    is_media=false
+) %}
+  <table class="ui striped table files fluid {{record.ui.access_status.id}}">
+    <thead>
+      <tr>
+        <th>{{_('Name')}}</th>
+        <th>{{_('Size')}}</th>
+        <th class>
+          {%- if config.RDM_ARCHIVE_DOWNLOAD_ENABLED %}
+            {% set archive_download_url = record.links.archive_media if is_media else record.links.archive %}
+            <a role="button" class="ui compact mini button right floated archive-link" href="{{ archive_download_url }}">
+              <i class="file archive icon button" aria-hidden="true"></i> {{_("Download all")}}
+            </a>
+          {%- endif %}
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+    {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
+    {%- set include_deleted_value = 0 -%}
+    {% if include_deleted %}
+      {%- set include_deleted_value = 1 -%}
+    {% endif %}
+    {% for file in files %}
+      {% if not file.access.hidden %}
+      {# updates the preview link if the file has a preview filename in metadata to direct to for preview and if that file is present if not then preview the current file #}
+       {%- set filename = file.metadata.preview if file.metadata and 'preview' in file.metadata and files|selectattr('key', 'equalto', file.metadata.preview)|list|length > 0 else file.key %}
+          {% if is_preview %}
+            {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1, preview=1) %}
+            {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=filename, preview=1, include_deleted=include_deleted_value) %}
+          {% else %}
+            {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1) %}
+            {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=filename, include_deleted=include_deleted_value) %}
+          {% endif %}
+
+        {%- set file_type = file.key.split('.')[-1] %}
+        <tr>
+          <td class="ten wide">
+            <div>
+              <a href="{{ file_url_download }}">{{ file.key }}</a>
+            </div>
+            <small class="ui text-muted font-tiny">{{ file.checksum }}
+            <div class="ui icon inline-block" data-tooltip="{{_('This is the file fingerprint (checksum), which can be used to verify the file integrity.')}}">
+              <i class="question circle checksum icon"></i>
+            </div>
+            </small>
+          </td>
+          <td>{{ file.size|filesizeformat(binary=binary_sizes) }}</td>
+          <td class="right aligned">
+            <span>
+              {% if with_preview and file_type|lower is previewable %}
+                <a role="button" class="ui compact mini button preview-link" href="{{ file_url_preview }}" target="preview-iframe" data-file-key="{{file.key}}">
+                  <i class="eye icon" aria-hidden="true"></i>{{_("Preview")}}
+                </a>
+              {% endif %}
+              <a role="button" class="ui compact mini button" href="{{ file_url_download }}">
+                <i class="download icon" aria-hidden="true"></i>{{_('Download')}}
+              </a>
+            </span>
+          </td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+    </tbody>
+  </table>
+{%- endmacro %}
+
+
+{% macro file_list_box(files, pid, is_preview, include_deleted, record) %}
+  {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
+  <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}" href="#files-list-accordion-panel">
+    <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
+      <div role="button" id="files-list-accordion-trigger" aria-controls="files-list-accordion-panel" aria-expanded="true" tabindex="0" class="trigger">
+        {{ _("Files") }}
+        <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
+        <i class="angle right icon" aria-hidden="true"></i>
+      </div>
+    </h3>
+
+    <div role="region" id="files-list-accordion-panel" aria-labelledby="files-list-accordion-trigger" class="active content pt-0">
+      {% if record.access.files == 'restricted' %}
+        <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
+          <i class="ui {{ record.ui.access_status.icon }} icon" aria-hidden="true"></i>
+          <h4 class="inline">{{ record.ui.access_status.title_l10n }}</h4>
+          <p>{{ record.ui.access_status.description_l10n }}</p>
+          {% if record.access.embargo.reason %}
+            <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
+          {% endif%}
+        </div>
+      {% endif %}
+      <div>
+        {{ file_list(files, pid, is_preview, include_deleted, record=record, download_endpoint="invenio_app_rdm_records.record_file_download") }}
+      </div>
+    </div>
+  </div>
+{%- endmacro %}
+
+{% macro media_file_list_box(files, pid, is_preview, include_deleted, record) %}
+  {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
+  <div class="ui accordion panel mb-10 {{ record.access.record }}" href="#media-files-preview-accordion-panel">
+    <h3 class="active title panel-heading {{ record.access.record }} m-0">
+      <div role="button" id="media-files-preview-accordion-trigger" aria-controls="media-files-preview-accordion-panel" aria-expanded="true" tabindex="0" class="trigger">
+        {{ _("System files") }}
+        <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
+        <i class="angle right icon" aria-hidden="true"></i>
+      </div>
+    </h3>
+
+    <div role="region" id="media-files-preview-accordion-panel" aria-labelledby="media-files-preview-accordion-trigger" class="active content pt-0">
+      {% if record.access.record == 'restricted'%}
+        <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
+          <i class="ui {{ record.ui.access_status.icon }} icon"></i>
+          <h4 class="inline">{{ record.ui.access_status.title_l10n }}</h4>
+
+          <p>{{ record.ui.access_status.description_l10n }}</p>
+          {% if record.access.embargo.reason %}
+            <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
+          {% endif%}
+        </div>
+      {% endif %}
+      <div>
+        {{ file_list(files, pid, is_preview, record=record, with_preview=false, download_endpoint="invenio_app_rdm_records.record_media_file_download", is_media=true) }}
+      </div>
+    </div>
+  </div>
+{%- endmacro %}

--- a/templates/semantic-ui/zenodo_rdm/records/detail.html
+++ b/templates/semantic-ui/zenodo_rdm/records/detail.html
@@ -21,14 +21,22 @@
       {%- if permissions.can_read_files -%}
         {# record has files AND user has permission to see files #}
         {%- set files = files | order_entries | selectattr("status", "==", "completed") | list %}
+        {%- if record.files.default_preview is defined -%}
+          {%- set default_preview_file = files | selectattr("key", "==", record.files.default_preview) | first %}
+          {# check if the file has a preview filename in metadata to direct to for preview and if that file is present if not then preview the current file #}
+          {%- set default_preview = default_preview_file.metadata.preview if default_preview_file and default_preview_file.metadata.preview in files|map(attribute='key') else default_preview_file.key if default_preview_file else None -%}
+        {%- else -%}
+          {%- set default_preview = None -%}
+        {%- endif -%}
+
         {%- if files|length > 0 -%}
           <h2 id="files-heading">{{ _('Files') }}</h2>
           {%- if files|has_previewable_files -%}
-            {%-set preview_file = files|select_preview_file(default_preview=record.files.default_preview) %}
+            {%- set preview_file = files|select_preview_file(default_preview=default_preview) %}
             {{ preview_file_box(preview_file, record.id, is_preview, record, include_deleted) }}
           {%- endif -%}
           {{ file_list_box(files, record.id, is_preview, include_deleted, record) }}
-        {% endif %}
+        {%- endif -%}
       {% else %}
         {# record has files BUT user does not have permission to see files #}
         <div

--- a/templates/semantic-ui/zenodo_rdm/records/detail.html
+++ b/templates/semantic-ui/zenodo_rdm/records/detail.html
@@ -35,7 +35,7 @@
             {%- set preview_file = files|select_preview_file(default_preview=default_preview) %}
             {{ preview_file_box(preview_file, record.id, is_preview, record, include_deleted) }}
           {%- endif -%}
-          {{ file_list_box(files, record.id, is_preview, include_deleted, record) }}
+          {{ file_list_box(files, record.id, is_preview, include_deleted, permissions, record) }}
         {%- endif -%}
       {% else %}
         {# record has files BUT user does not have permission to see files #}


### PR DESCRIPTION
Closes Issue https://github.com/zenodo/ops/issues/476

- If a file has a filename in metadata.preview and that file is present in files
  - Then it previews that file otherwise default to the current file on initial preview
  - Also generates links for preview button based on that
  
- Added annotate button for redirection to annostar instance for specific communities

- The files right now have been uploaded with access hidden in the screenshot below for the specific usecase

<img width="1033" alt="Screenshot 2024-07-05 at 16 58 45" src="https://github.com/zenodo/zenodo-rdm/assets/51617644/846e32a8-e362-403b-8105-b3e24a229a5c">
