### PR TITLE
landing page: updated linked records layout

### DIFF
--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/BlrSearch.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/BlrSearch.js
@@ -74,8 +74,8 @@ export const BlrSearch = ({ endpoint, recordDOI, resourceType, blrId }) => {
     sortBy: "bestmatch",
     sortOrder: "asc",
     page: 1,
-    size: 4,
-    layout: "list",
+    size: 12,
+    layout: "grid",
   };
 
   return (

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/LayoutSwitchButtons.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/LayoutSwitchButtons.js
@@ -23,29 +23,40 @@
 import React from "react";
 import { PropTypes } from "prop-types";
 import { Button } from "semantic-ui-react";
+import { withState } from "react-searchkit";
 
-export const LayoutSwitchButtons = ({ currentLayout, onLayoutChange }) => {
-  return (
-    <Button.Group>
-      <Button
-        icon="th list"
-        name="list"
-        active={currentLayout === "list"}
-        onClick={() => onLayoutChange("list")}
-        aria-label="List view"
-      />
-      <Button
-        icon="th"
-        name="grid"
-        active={currentLayout === "grid"}
-        onClick={() => onLayoutChange("grid")}
-        aria-label="Grid view"
-      />
-    </Button.Group>
-  );
-};
+export const LayoutSwitchButtons = withState(
+  ({ updateQueryState, currentQueryState, currentLayout, onLayoutChange }) => {
+    const handleLayoutChange = (layout) => {
+      const numOfRecords = layout === "grid" ? 12 : 6;
+      updateQueryState({ ...currentQueryState, size: numOfRecords });
+      onLayoutChange(layout);
+    };
+
+    return (
+      <Button.Group>
+        <Button
+          icon="th"
+          name="grid"
+          active={currentLayout === "grid"}
+          onClick={() => handleLayoutChange("grid")}
+          aria-label="Grid view"
+        />
+        <Button
+          icon="th list"
+          name="list"
+          active={currentLayout === "list"}
+          onClick={() => handleLayoutChange("list")}
+          aria-label="List view"
+        />
+      </Button.Group>
+    );
+  }
+);
 
 LayoutSwitchButtons.propTypes = {
   currentLayout: PropTypes.string.isRequired,
   onLayoutChange: PropTypes.func.isRequired,
+  updateQueryState: PropTypes.func.isRequired,
+  currentQueryState: PropTypes.object.isRequired,
 };

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/ResultsLayout.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/blr-related-works/components/ResultsLayout.js
@@ -35,7 +35,7 @@ ResultsListLayout.propTypes = {
 };
 
 export const ResultsGridLayout = ({ results }) => (
-  <Grid columns="4" doubling>
+  <Grid columns="4" doubling stackable>
     {results}
   </Grid>
 );


### PR DESCRIPTION
Layout for Linked Records
- Defaults to grid view
- Updated grid and list layout for number of records to display

## **Before**
### **Grid**
<img width="1063" alt="Screenshot 2024-08-20 at 14 27 00" src="https://github.com/user-attachments/assets/a9b3d159-0593-4941-a3c0-569863117874">

### **List**
<img width="1016" alt="Screenshot 2024-08-20 at 14 26 55" src="https://github.com/user-attachments/assets/cd90eb9c-74f8-4d85-a2a9-abba22a8b5db">


## **After**
### **Grid**
<img width="1022" alt="Screenshot 2024-08-20 at 14 41 04" src="https://github.com/user-attachments/assets/797e1320-463c-4484-829c-746f49ffeb47">

### **List**
<img width="1134" alt="Screenshot 2024-08-20 at 14 26 30" src="https://github.com/user-attachments/assets/a43f2c3d-528f-4490-a119-1639de65da91">

