### PR TITLE
installation: bump dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,6 @@ invenio-logging = {extras = ["sentry_sdk"], version = "~=2.0"}
 sentry-sdk = ">=1.45,<2.0.0"
 # Temporarily pinned
 invenio-communities = "<14.6.0"
-invenio-rdm-records = "<11.7.0"
 zenodo_rdm = {editable="True", path="./site"}
 zenodo_legacy = {editable="True", path="./legacy"}
 # TODO: Remove once we fix PyPI package issues

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e33e85d62dd33608c090a77f86912cb329885a0c84cb815b0aceab9587b6f0ba"
+            "sha256": "bb9c80674928f46a8e993fb58bf78e454fc2299a03a1977cd947ba0172cc6db2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -882,7 +882,7 @@
                 "sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da",
                 "sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33"
             ],
-            "markers": "python_version < '3.13' and (platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32'))))))",
+            "markers": "python_version >= '3' and (platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32'))))))",
             "version": "==3.0.3"
         },
         "html5lib": {
@@ -934,19 +934,19 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:11901fa0c2f97919b288679932bb64febaeacf289d18ac84dd68cb2e74213369",
-                "sha256:72e8d4399996132204f9a16dcc751af254a48f8d1b20b9ff0f98d4a8f901e73d"
+                "sha256:66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1",
+                "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==8.2.0"
+            "version": "==8.4.0"
         },
         "importlib-resources": {
             "hashes": [
-                "sha256:6cbfbefc449cc6e2095dd184691b7a12a04f40bc75dd4c55d31c34f174cdf57a",
-                "sha256:8bba8c54a8a3afaa1419910845fa26ebd706dc716dd208d9b158b4b6966f5c5c"
+                "sha256:2d6dfe3b9e055f72495c2085890837fc8c758984e209115c8792bddcb762cd93",
+                "sha256:4a202b9b9d38563b46da59221d77bb73862ab5d79d461307bcb826d725448b98"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==6.4.2"
+            "version": "==6.4.3"
         },
         "infinity": {
             "hashes": [
@@ -1009,7 +1009,7 @@
                 "sha256:81fe92d5da299cdb0cadd3c9e24840144adb42c24ab762886a0c45a896d47436",
                 "sha256:9df8903aba03376088c43ddcf98513560e4e697e466ffc47e217756e566b1478"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==13.0.0b0.dev13"
         },
         "invenio-assets": {
@@ -1054,11 +1054,12 @@
         },
         "invenio-communities": {
             "hashes": [
-                "sha256:4b8676f10cc46b2f486d1e818e3fc0c44e321a21740417578e215c964583ef94",
-                "sha256:f151af00d249433c705b4d5bfc80d45914425e0dc581a65529bf2230f2d2c047"
+                "sha256:70d1089490f08d584dd5d02a769e17988e9f54fe36d5abac6af274fc25c78bd7",
+                "sha256:aa633c40f110634bed479ea24707f3ad7fed02870dcddf3bd4b455f2666c5fa9"
             ],
             "index": "pypi",
-            "version": "==14.5.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==14.5.3"
         },
         "invenio-config": {
             "hashes": [
@@ -1069,6 +1070,10 @@
             "version": "==1.0.4"
         },
         "invenio-db": {
+            "extras": [
+                "mysql",
+                "postgresql"
+            ],
             "hashes": [
                 "sha256:c02120e22d22498fcd23c3761a1d160c177261c760c38ccfddb4d671fcb7ddef",
                 "sha256:cbbe6d53678a04e21afd8220498a9ddde041bf5c7afd66df00fb46907b109c13"
@@ -1147,7 +1152,7 @@
                 "sha256:0e8bbb6a3fe862ac9b3c2ec2d12e5589b836d51b4139d87e41ee538801e6d89c",
                 "sha256:71e0eb80488955a6d7a569074da38de5586e9c4b57a4e6e6de94a25834953026"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.1.1"
         },
         "invenio-mail": {
@@ -1224,11 +1229,11 @@
         },
         "invenio-rdm-records": {
             "hashes": [
-                "sha256:c3371e5c8c9cdf32c00e38783af20efcf0edc499313f1c40c21abfc8432c4af9",
-                "sha256:dc63c6e496145e0d8f8d7c0e9f4d880136ea5c08c43f2f451da260e4172444b2"
+                "sha256:44640ec748dfcf3409749663b64ec89d2b0895fcc138bae771e54c4a0db3514e",
+                "sha256:e98d62904d0fdae641ddfdae2ced04a728d64ce549cab473fc0b857e297f9bd7"
             ],
-            "index": "pypi",
-            "version": "==11.6.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==11.8.0"
         },
         "invenio-records": {
             "hashes": [
@@ -1349,11 +1354,11 @@
         },
         "invenio-vocabularies": {
             "hashes": [
-                "sha256:17625578a5d3a2767740ac6b57563581454ada1f3cae65d1a490238f3c1badac",
-                "sha256:dca843773791f769360ddfaf1533d2a10e8c92b2bd572bfd72f4203389713629"
+                "sha256:bfd1ee520ba7835f5a2813c363b18060add497c5c1c371e229a838d8a72162f1",
+                "sha256:d76dbeb5a5a660abd942ac4cfc513f04a6ae26be57a82e41482038655d711b8e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.4.0"
+            "version": "==4.5.0"
         },
         "invenio-webhooks": {
             "hashes": [
@@ -1369,6 +1374,7 @@
                 "sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.9'",
             "version": "==8.18.1"
         },
         "isbnlib": {
@@ -1446,6 +1452,7 @@
                 "sha256:a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==4.17.3"
         },
         "jupyter-client": {
@@ -1611,11 +1618,11 @@
         },
         "markdown": {
             "hashes": [
-                "sha256:48f276f4d8cfb8ce6527c8f79e2ee29708508bf4d40aa410fbc3b4ee832c850f",
-                "sha256:ed4f41f6daecbeeb96e576ce414c41d2d876daa9a16cb35fa8ed8c2ddfad0224"
+                "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2",
+                "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.6"
+            "version": "==3.7"
         },
         "markupsafe": {
             "hashes": [
@@ -1685,11 +1692,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:4f57c5e050a54d66361e826f94fba213eb10b67b2fdb02c3e0343ce207ba1662",
-                "sha256:86ce7fb914aa865001a4b2092c4c2872d13bc347f3d42673272cabfdbad386f1"
+                "sha256:4972f529104a220bb8637d595aa4c9762afbe7f7a77d82dc58c1615d70c5823e",
+                "sha256:71a2dce49ef901c3f97ed296ae5051135fd3febd2bf43afe0ae9a82143a494d9"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.21.3"
+            "version": "==3.22.0"
         },
         "marshmallow-oneofschema": {
             "hashes": [
@@ -1968,10 +1975,10 @@
         },
         "opensearch-py": {
             "hashes": [
-                "sha256:0b7c27e8ed84c03c99558406927b6161f186a72502ca6d0325413d8e5523ba96",
-                "sha256:b6e78b685dd4e9c016d7a4299cf1de69e299c88322e3f81c716e6e23fe5683c1"
+                "sha256:6a36535efcda870c820fd84c4bda96d7d57fc900a8c7dec660a48c079904df97",
+                "sha256:c09a73727868c29f86ffbed1e987afb7f86bcce983b28bf69249cfad8c831d68"
             ],
-            "version": "==2.6.0"
+            "version": "==2.7.0"
         },
         "ordered-set": {
             "hashes": [
@@ -2528,118 +2535,118 @@
         },
         "pyzmq": {
             "hashes": [
-                "sha256:038ae4ffb63e3991f386e7fda85a9baab7d6617fe85b74a8f9cab190d73adb2b",
-                "sha256:05bacc4f94af468cc82808ae3293390278d5f3375bb20fef21e2034bb9a505b6",
-                "sha256:0614aed6f87d550b5cecb03d795f4ddbb1544b78d02a4bd5eecf644ec98a39f6",
-                "sha256:08f74904cb066e1178c1ec706dfdb5c6c680cd7a8ed9efebeac923d84c1f13b1",
-                "sha256:093a1a3cae2496233f14b57f4b485da01b4ff764582c854c0f42c6dd2be37f3d",
-                "sha256:0a1f6ea5b1d6cdbb8cfa0536f0d470f12b4b41ad83625012e575f0e3ecfe97f0",
-                "sha256:0e6cea102ffa16b737d11932c426f1dc14b5938cf7bc12e17269559c458ac334",
-                "sha256:263cf1e36862310bf5becfbc488e18d5d698941858860c5a8c079d1511b3b18e",
-                "sha256:28a8b2abb76042f5fd7bd720f7fea48c0fd3e82e9de0a1bf2c0de3812ce44a42",
-                "sha256:2ae7c57e22ad881af78075e0cea10a4c778e67234adc65c404391b417a4dda83",
-                "sha256:2cd0f4d314f4a2518e8970b6f299ae18cff7c44d4a1fc06fc713f791c3a9e3ea",
-                "sha256:2fa76ebcebe555cce90f16246edc3ad83ab65bb7b3d4ce408cf6bc67740c4f88",
-                "sha256:314d11564c00b77f6224d12eb3ddebe926c301e86b648a1835c5b28176c83eab",
-                "sha256:347e84fc88cc4cb646597f6d3a7ea0998f887ee8dc31c08587e9c3fd7b5ccef3",
-                "sha256:359c533bedc62c56415a1f5fcfd8279bc93453afdb0803307375ecf81c962402",
-                "sha256:393daac1bcf81b2a23e696b7b638eedc965e9e3d2112961a072b6cd8179ad2eb",
-                "sha256:3b3b8e36fd4c32c0825b4461372949ecd1585d326802b1321f8b6dc1d7e9318c",
-                "sha256:3c397b1b450f749a7e974d74c06d69bd22dd362142f370ef2bd32a684d6b480c",
-                "sha256:3d3146b1c3dcc8a1539e7cc094700b2be1e605a76f7c8f0979b6d3bde5ad4072",
-                "sha256:3ee647d84b83509b7271457bb428cc347037f437ead4b0b6e43b5eba35fec0aa",
-                "sha256:416ac51cabd54f587995c2b05421324700b22e98d3d0aa2cfaec985524d16f1d",
-                "sha256:451e16ae8bea3d95649317b463c9f95cd9022641ec884e3d63fc67841ae86dfe",
-                "sha256:45cb1a70eb00405ce3893041099655265fabcd9c4e1e50c330026e82257892c1",
-                "sha256:46d6800b45015f96b9d92ece229d92f2aef137d82906577d55fadeb9cf5fcb71",
-                "sha256:471312a7375571857a089342beccc1a63584315188560c7c0da7e0a23afd8a5c",
-                "sha256:471880c4c14e5a056a96cd224f5e71211997d40b4bf5e9fdded55dafab1f98f2",
-                "sha256:5384c527a9a004445c5074f1e20db83086c8ff1682a626676229aafd9cf9f7d1",
-                "sha256:57bb2acba798dc3740e913ffadd56b1fcef96f111e66f09e2a8db3050f1f12c8",
-                "sha256:58c33dc0e185dd97a9ac0288b3188d1be12b756eda67490e6ed6a75cf9491d79",
-                "sha256:59d0acd2976e1064f1b398a00e2c3e77ed0a157529779e23087d4c2fb8aaa416",
-                "sha256:5a6ed52f0b9bf8dcc64cc82cce0607a3dfed1dbb7e8c6f282adfccc7be9781de",
-                "sha256:5bc2431167adc50ba42ea3e5e5f5cd70d93e18ab7b2f95e724dd8e1bd2c38120",
-                "sha256:5cca7b4adb86d7470e0fc96037771981d740f0b4cb99776d5cb59cd0e6684a73",
-                "sha256:61dfa5ee9d7df297c859ac82b1226d8fefaf9c5113dc25c2c00ecad6feeeb04f",
-                "sha256:63c1d3a65acb2f9c92dce03c4e1758cc552f1ae5c78d79a44e3bb88d2fa71f3a",
-                "sha256:65c6e03cc0222eaf6aad57ff4ecc0a070451e23232bb48db4322cc45602cede0",
-                "sha256:67976d12ebfd61a3bc7d77b71a9589b4d61d0422282596cf58c62c3866916544",
-                "sha256:68a0a1d83d33d8367ddddb3e6bb4afbb0f92bd1dac2c72cd5e5ddc86bdafd3eb",
-                "sha256:6c5aeea71f018ebd3b9115c7cb13863dd850e98ca6b9258509de1246461a7e7f",
-                "sha256:754c99a9840839375ee251b38ac5964c0f369306eddb56804a073b6efdc0cd88",
-                "sha256:75a95c2358fcfdef3374cb8baf57f1064d73246d55e41683aaffb6cfe6862917",
-                "sha256:7688653574392d2eaeef75ddcd0b2de5b232d8730af29af56c5adf1df9ef8d6f",
-                "sha256:77ce6a332c7e362cb59b63f5edf730e83590d0ab4e59c2aa5bd79419a42e3449",
-                "sha256:7907419d150b19962138ecec81a17d4892ea440c184949dc29b358bc730caf69",
-                "sha256:79e45a4096ec8388cdeb04a9fa5e9371583bcb826964d55b8b66cbffe7b33c86",
-                "sha256:7bcbfbab4e1895d58ab7da1b5ce9a327764f0366911ba5b95406c9104bceacb0",
-                "sha256:80b0c9942430d731c786545da6be96d824a41a51742e3e374fedd9018ea43106",
-                "sha256:8b88641384e84a258b740801cd4dbc45c75f148ee674bec3149999adda4a8598",
-                "sha256:8d4dac7d97f15c653a5fedcafa82626bd6cee1450ccdaf84ffed7ea14f2b07a4",
-                "sha256:8d906d43e1592be4b25a587b7d96527cb67277542a5611e8ea9e996182fae410",
-                "sha256:8efb782f5a6c450589dbab4cb0f66f3a9026286333fe8f3a084399149af52f29",
-                "sha256:906e532c814e1d579138177a00ae835cd6becbf104d45ed9093a3aaf658f6a6a",
-                "sha256:90d4feb2e83dfe9ace6374a847e98ee9d1246ebadcc0cb765482e272c34e5820",
-                "sha256:911c43a4117915203c4cc8755e0f888e16c4676a82f61caee2f21b0c00e5b894",
-                "sha256:91d1a20bdaf3b25f3173ff44e54b1cfbc05f94c9e8133314eb2962a89e05d6e3",
-                "sha256:94c4262626424683feea0f3c34951d39d49d354722db2745c42aa6bb50ecd93b",
-                "sha256:96d7c1d35ee4a495df56c50c83df7af1c9688cce2e9e0edffdbf50889c167595",
-                "sha256:9869fa984c8670c8ab899a719eb7b516860a29bc26300a84d24d8c1b71eae3ec",
-                "sha256:98c03bd7f3339ff47de7ea9ac94a2b34580a8d4df69b50128bb6669e1191a895",
-                "sha256:995301f6740a421afc863a713fe62c0aaf564708d4aa057dfdf0f0f56525294b",
-                "sha256:998444debc8816b5d8d15f966e42751032d0f4c55300c48cc337f2b3e4f17d03",
-                "sha256:9a6847c92d9851b59b9f33f968c68e9e441f9a0f8fc972c5580c5cd7cbc6ee24",
-                "sha256:9bdfcb74b469b592972ed881bad57d22e2c0acc89f5e8c146782d0d90fb9f4bf",
-                "sha256:9f136a6e964830230912f75b5a116a21fe8e34128dcfd82285aa0ef07cb2c7bd",
-                "sha256:a0f0ab9df66eb34d58205913f4540e2ad17a175b05d81b0b7197bc57d000e829",
-                "sha256:a4b7a989c8f5a72ab1b2bbfa58105578753ae77b71ba33e7383a31ff75a504c4",
-                "sha256:a7b8aab50e5a288c9724d260feae25eda69582be84e97c012c80e1a5e7e03fb2",
-                "sha256:ad875277844cfaeca7fe299ddf8c8d8bfe271c3dc1caf14d454faa5cdbf2fa7a",
-                "sha256:add52c78a12196bc0fda2de087ba6c876ea677cbda2e3eba63546b26e8bf177b",
-                "sha256:b10163e586cc609f5f85c9b233195554d77b1e9a0801388907441aaeb22841c5",
-                "sha256:b24079a14c9596846bf7516fe75d1e2188d4a528364494859106a33d8b48be38",
-                "sha256:b281b5ff5fcc9dcbfe941ac5c7fcd4b6c065adad12d850f95c9d6f23c2652384",
-                "sha256:b3bb34bebaa1b78e562931a1687ff663d298013f78f972a534f36c523311a84d",
-                "sha256:b45e6445ac95ecb7d728604bae6538f40ccf4449b132b5428c09918523abc96d",
-                "sha256:ba0a31d00e8616149a5ab440d058ec2da621e05d744914774c4dde6837e1f545",
-                "sha256:baba2fd199b098c5544ef2536b2499d2e2155392973ad32687024bd8572a7d1c",
-                "sha256:bd13f0231f4788db619347b971ca5f319c5b7ebee151afc7c14632068c6261d3",
-                "sha256:bd3f6329340cef1c7ba9611bd038f2d523cea79f09f9c8f6b0553caba59ec562",
-                "sha256:bdeb2c61611293f64ac1073f4bf6723b67d291905308a7de9bb2ca87464e3273",
-                "sha256:bef24d3e4ae2c985034439f449e3f9e06bf579974ce0e53d8a507a1577d5b2ab",
-                "sha256:c0665d85535192098420428c779361b8823d3d7ec4848c6af3abb93bc5c915bf",
-                "sha256:c5668dac86a869349828db5fc928ee3f58d450dce2c85607067d581f745e4fb1",
-                "sha256:c9b9305004d7e4e6a824f4f19b6d8f32b3578aad6f19fc1122aaf320cbe3dc83",
-                "sha256:ccb42ca0a4a46232d716779421bbebbcad23c08d37c980f02cc3a6bd115ad277",
-                "sha256:ce6f2b66799971cbae5d6547acefa7231458289e0ad481d0be0740535da38d8b",
-                "sha256:d36b8fffe8b248a1b961c86fbdfa0129dfce878731d169ede7fa2631447331be",
-                "sha256:d3dd5523ed258ad58fed7e364c92a9360d1af8a9371e0822bd0146bdf017ef4c",
-                "sha256:d416f2088ac8f12daacffbc2e8918ef4d6be8568e9d7155c83b7cebed49d2322",
-                "sha256:d4fafc2eb5d83f4647331267808c7e0c5722c25a729a614dc2b90479cafa78bd",
-                "sha256:d5c8b17f6e8f29138678834cf8518049e740385eb2dbf736e8f07fc6587ec682",
-                "sha256:d9270fbf038bf34ffca4855bcda6e082e2c7f906b9eb8d9a8ce82691166060f7",
-                "sha256:dcc37d9d708784726fafc9c5e1232de655a009dbf97946f117aefa38d5985a0f",
-                "sha256:ddbb2b386128d8eca92bd9ca74e80f73fe263bcca7aa419f5b4cbc1661e19741",
-                "sha256:e1e5d0a25aea8b691a00d6b54b28ac514c8cc0d8646d05f7ca6cb64b97358250",
-                "sha256:e5c88b2f13bcf55fee78ea83567b9fe079ba1a4bef8b35c376043440040f7edb",
-                "sha256:e7eca8b89e56fb8c6c26dd3e09bd41b24789022acf1cf13358e96f1cafd8cae3",
-                "sha256:e8746ce968be22a8a1801bf4a23e565f9687088580c3ed07af5846580dd97f76",
-                "sha256:ec7248673ffc7104b54e4957cee38b2f3075a13442348c8d651777bf41aa45ee",
-                "sha256:ecb6c88d7946166d783a635efc89f9a1ff11c33d680a20df9657b6902a1d133b",
-                "sha256:ef3b048822dca6d231d8a8ba21069844ae38f5d83889b9b690bf17d2acc7d099",
-                "sha256:f133d05aaf623519f45e16ab77526e1e70d4e1308e084c2fb4cedb1a0c764bbb",
-                "sha256:f3292d384537b9918010769b82ab3e79fca8b23d74f56fc69a679106a3e2c2cf",
-                "sha256:f774841bb0e8588505002962c02da420bcfb4c5056e87a139c6e45e745c0e2e2",
-                "sha256:f9499c70c19ff0fbe1007043acb5ad15c1dec7d8e84ab429bca8c87138e8f85c",
-                "sha256:f99de52b8fbdb2a8f5301ae5fc0f9e6b3ba30d1d5fc0421956967edcc6914242",
-                "sha256:fa25a620eed2a419acc2cf10135b995f8f0ce78ad00534d729aa761e4adcef8a",
-                "sha256:fbf558551cf415586e91160d69ca6416f3fce0b86175b64e4293644a7416b81b",
-                "sha256:fc82269d24860cfa859b676d18850cbb8e312dcd7eada09e7d5b007e2f3d9eb1",
-                "sha256:ff832cce719edd11266ca32bc74a626b814fff236824aa1aeaad399b69fe6eae"
+                "sha256:0065026e624052a51033857e5cd45a94b52946b44533f965f0bdf182460e965d",
+                "sha256:00f39c367bbd6aa8e4bc36af6510561944c619b58eb36199fa334b594a18f615",
+                "sha256:0841633446cb1539a832a19bb24c03a20c00887d0cedd1d891b495b07e5c5cb5",
+                "sha256:08956c26dbcd4fd8835cb777a16e21958ed2412317630e19f0018d49dbeeb470",
+                "sha256:0cf1d980c969fb9e538f52abd2227f09e015096bc5c3ef7aa26e0d64051c1db8",
+                "sha256:146956aec7d947c5afc5e7da0841423d7a53f84fd160fff25e682361dcfb32cb",
+                "sha256:14bdbae02f72f4716b0ffe7500e9da303d719ddde1f3dcfb4c4f6cc1cf73bb02",
+                "sha256:18da8e84dbc30688fd2baefd41df7190607511f916be34f9a24b0e007551822e",
+                "sha256:2067e63fd9d5c13cfe12624dab0366053e523b37a7a01678ce4321f839398939",
+                "sha256:23f2fe4fb567e8098ebaa7204819658195b10ddd86958a97a6058eed2901eed3",
+                "sha256:2508bdc8ab246e5ed7c92023d4352aaad63020ca3b098a4e3f1822db202f703d",
+                "sha256:25d128524207f53f7aae7c5abdc2b63f8957a060b00521af5ffcd20986b5d8f4",
+                "sha256:26131b1cec02f941ed2d2b4b8cc051662b1c248b044eff5069df1f500bbced56",
+                "sha256:29de77ba1b1877fe7defc1b9140e65cbd35f72a63bc501e56c2eae55bde5fff4",
+                "sha256:2ae7aa1408778dc74582a1226052b930f9083b54b64d7e6ef6ec0466cfdcdec2",
+                "sha256:2b045647caf620ce0ed6c8fd9fb6a73116f99aceed966b152a5ba1b416d25311",
+                "sha256:2c0fdb7b758e0e1605157e480b00b3a599073068a37091a1c75ec65bf7498645",
+                "sha256:2f6071ec95af145d7b659dae6786871cd85f0acc599286b6f8ba0c74592d83dd",
+                "sha256:32123ff0a6db521aadf2b95201e967a4e0d11fb89f73663a99d2f54881c07214",
+                "sha256:32de51744820857a6f7c3077e620ab3f607d0e4388dfead885d5124ab9bcdc5e",
+                "sha256:362cac2423e36966d336d79d3ec3eafeabc153ee3e7a5cf580d7e74a34b3d912",
+                "sha256:3abb15df0c763339edb27a644c19381b2425ddd1aea3dbd77c1601a3b31867b8",
+                "sha256:3ddbd851a3a2651fdc5065a2804d50cf2f4b13b1bcd66de8e9e855d0217d4fcd",
+                "sha256:3e3b66fe6131b4f33d239f7d4c3bfb2f8532d8644bae3b3da4f3987073edac55",
+                "sha256:3ee5cbf2625b94de21c68d0cefd35327c8dfdbd6a98fcc41682b4e8bb00d841f",
+                "sha256:40908ec2dd3b29bbadc0916a0d3c87f8dbeebbd8fead8e618539f09e0506dec4",
+                "sha256:4350233569b4bbef88595c5e77ee38995a6f1f1790fae148b578941bfffd1c24",
+                "sha256:4437af9fee7a58302dbd511cc49f0cc2b35c112a33a1111fb123cf0be45205ca",
+                "sha256:443ebf5e261a95ee9725693f2a5a71401f89b89df0e0ea58844b074067aac2f1",
+                "sha256:472cacd16f627c06d3c8b2d374345ab74446bae913584a6245e2aa935336d929",
+                "sha256:48dee75c2a9fa4f4a583d4028d564a0453447ee1277a29b07acc3743c092e259",
+                "sha256:4d4c7fe5e50e269f9c63a260638488fec194a73993008618a59b54c47ef6ae72",
+                "sha256:4e1fcdc333afbf9918d0a614a6e10858aede7da49a60f6705a77e343fe86a317",
+                "sha256:50f0669324e27cc2091ef6ab76ca7112f364b6249691790b4cffce31e73fda28",
+                "sha256:583f73b113b8165713b6ce028d221402b1b69483055b5aa3f991937e34dd1ead",
+                "sha256:59b57e912feef6951aec8bb03fe0faa5ad5f36962883c72a30a9c965e6d988fd",
+                "sha256:5ccfcf13e80719f6a2d9c0a021d9e47d4550907a29253554be2c09582f6d7963",
+                "sha256:5e6f39ecb8eb7bfcb976c49262e8cf83ff76e082b77ca23ba90c9b6691a345be",
+                "sha256:62b5180e23e6f581600459cd983473cd723fdc64350f606d21407c99832aaf5f",
+                "sha256:63351392f948b5d50b9f55161994bc4feedbfb3f3cfe393d2f503dea2c3ec445",
+                "sha256:65e2a18e845c6ea7ab849c70db932eaeadee5edede9e379eb21c0a44cf523b2e",
+                "sha256:6c8087a3281c20b1d11042d372ed5a47734af05975d78e4d1d6e7bd1018535f3",
+                "sha256:6f0512fc87629ad968889176bf2165d721cd817401a281504329e2a2ed0ca6a3",
+                "sha256:6f34453ef3496ca3462f30435bf85f535f9550392987341f9ccc92c102825a79",
+                "sha256:6ff14c2fae6c0c2c1c02590c5c5d75aa1db35b859971b3ca2fcd28f983d9f2b6",
+                "sha256:70af4c9c991714ef1c65957605a8de42ef0d0620dd5f125953c8e682281bdb80",
+                "sha256:717960855f2d6fdc2dba9df49dff31c414187bb11c76af36343a57d1f7083d9a",
+                "sha256:732f957441e5b1c65a7509395e6b6cafee9e12df9aa5f4bf92ed266fe0ba70ee",
+                "sha256:741bdb4d96efe8192616abdc3671931d51a8bcd38c71da2d53fb3127149265d1",
+                "sha256:75bd448a28b1001b6928679015bc95dd5f172703ed30135bb9e34fc9cda0a3e7",
+                "sha256:76154943e4c4054b2591792eb3484ef1dd23d59805759f9cebd2f010aa30ee8c",
+                "sha256:76390d3d66406cb01b9681c382874400e9dfd77f30ecdea4bd1bf5226dd4aff0",
+                "sha256:7a5342110510045a47de1e87f5f1dcc1d9d90109522316dc9830cfc6157c800f",
+                "sha256:7c506a51cb01bb997a3f6440db0d121e5e7a32396e9948b1fdb6a7bfa67243f4",
+                "sha256:7dfabc180a4da422a4b349c63077347392463a75fa07aa3be96712ed6d42c547",
+                "sha256:809673947e95752e407aaaaf03f205ee86ebfff9ca51db6d4003dfd87b8428d1",
+                "sha256:8285b25aa20fcc46f1ca4afbc39fd3d5f2fe4c4bbf7f2c7f907a214e87a70024",
+                "sha256:85f2d2ee5ea9a8f1de86a300e1062fbab044f45b5ce34d20580c0198a8196db0",
+                "sha256:8d042d6446cab3a1388b38596f5acabb9926b0b95c3894c519356b577a549458",
+                "sha256:8d4234f335b0d0842f7d661d8cd50cbad0729be58f1c4deb85cd96b38fe95025",
+                "sha256:8eaffcd6bf6a9d00b66a2052a33fa7e6a6575427e9644395f13c3d070f2918dc",
+                "sha256:92eca4f80e8a748d880e55d3cf57ef487692e439f12d5c5a2e1cce84aaa7f6cb",
+                "sha256:9498ac427d20d0e0ef0e4bbd6200841e91640dfdf619f544ceec7f464cfb6070",
+                "sha256:9521b874fd489495865172f344e46e0159095d1f161858e3fc6e28e43ca15160",
+                "sha256:9763a8d3f5f74ef679989b373c37cc22e8d07e56d26439205cb83edb7722357f",
+                "sha256:9f380d5333fc7cd17423f486125dcc073918676e33db70a6a8172b19fc78d23d",
+                "sha256:a4cbecda4ddbfc1e309c3be04d333f9be3fc6178b8b6592b309676f929767a15",
+                "sha256:a7db05d8b7cd1a8c6610e9e9aa55d525baae7a44a43e18bc3260eb3f92de96c6",
+                "sha256:a8234571df7816f99dde89c3403cb396d70c6554120b795853a8ea56fcc26cd3",
+                "sha256:a83653c6bbe5887caea55e49fbd2909c14b73acf43bcc051eb60b2d514bbd46e",
+                "sha256:a880240597010914ffb1d6edd04d3deb7ce6a2abf79a0012751438d13630a671",
+                "sha256:aa79c528706561306938b275f89bb2c6985ce08469c27e5de05bc680df5e826f",
+                "sha256:abad7b897e960d577eb4a0f3f789c1780bc3ffe2e7c27cf317e7c90ad26acf12",
+                "sha256:af690ea4be6ca92a67c2b44a779a023bf0838e92d48497a2268175dc4a505691",
+                "sha256:b1bb952d1e407463c9333ea7e0c0600001e54e08ce836d4f0aff1fb3f902cf63",
+                "sha256:b8e153f5dffb0310af71fc6fc9cd8174f4c8ea312c415adcb815d786fee78179",
+                "sha256:bc5df31e36e4fddd4c8b5c42daee8d54d7b529e898ac984be97bf5517de166a7",
+                "sha256:bc904e86de98f8fc5bd41597da5d61232d2d6d60c4397f26efffabb961b2b245",
+                "sha256:bc994e220c1403ae087d7f0fa45129d583e46668a019e389060da811a5a9320e",
+                "sha256:be3fc2b11c0c384949cf1f01f9a48555039408b0f3e877863b1754225635953e",
+                "sha256:c11a95d3f6fc7e714ccd1066f68f9c1abd764a8b3596158be92f46dd49f41e03",
+                "sha256:c513d829a548c2d5c88983167be2b3aa537f6d1191edcdc6fcd8999e18bdd994",
+                "sha256:c5248e6e0fcbbbc912982e99cdd51c342601f495b0fa5bd667f3bdbdbf3e170f",
+                "sha256:c70dab93d98b2bf3f0ac1265edbf6e7f83acbf71dabcc4611889bb0dea45bed7",
+                "sha256:cc09b1de8b985ca5a0ca343dd7fb007267c6b329347a74e200f4654268084239",
+                "sha256:cc109be2ee3638035d276e18eaf66a1e1f44201c0c4bea4ee0c692766bbd3570",
+                "sha256:cc8d655627d775475eafdcf0e49e74bcc1e5e90afd9ab813b4da98f092ed7b93",
+                "sha256:ce05841322b58510607f9508a573138d995a46c7928887bc433de9cb760fd2ad",
+                "sha256:cf4be7460a0c1bc71e9b0e64ecdd75a86386ca6afaa36641686f5542d0314e9d",
+                "sha256:cf4e283f97688d993cb7a8acbc22889effbbb7cbaa19ee9709751f44be928f5d",
+                "sha256:d0da97e65ee73261dba70469cc8f63d8da3a8a825337a2e3d246b9e95141cdd0",
+                "sha256:d3df226ab7464684ae6706e20a5cbab717c3735a7e409b3fa598b754d49f1946",
+                "sha256:d74b925d997e4f92b042bdd7085cd0a309ee0fd7cb4dc376059bbff6b32ff34f",
+                "sha256:db1b7e2b50ef21f398036786da4c153db63203a402396d9f21e08ea61f3f8dba",
+                "sha256:de6f384864a959866b782e6a3896538d1424d183f2d3c7ef079f71dcecde7284",
+                "sha256:def7ae3006924b8a0c146a89ab4008310913fa903beedb95e25dea749642528e",
+                "sha256:e03be7ed17836c9434cce0668ac1e2cc9143d7169f90f46a0167f6155e176e32",
+                "sha256:e790602d7ea1d6c7d8713d571226d67de7ffe47b1e22ae2c043ebd537de1bccb",
+                "sha256:e80345900ae241c2c51bead7c9fa247bba6d4b2a83423e9791bae8b0a7f12c52",
+                "sha256:ebef7d3fe11fe4c688f08bc0211a976c3318c097057f258428200737b9fff4da",
+                "sha256:ec8fe214fcc45dfb0c32e4a7ad1db20244ba2d2fecbf0cbf9d5242d81ca0a375",
+                "sha256:f0a45102ad7ed9f9ddf2bd699cc5df37742cf7301111cba06001b927efecb120",
+                "sha256:f1483d4975ae1b387b39bb8e23d1ff32fe5621aa9e4ed3055d05e9c5613fea53",
+                "sha256:f218179c90a12d660906e04b25a340dd63e9743000ba16232ddaf46888f269da",
+                "sha256:f66dcb6625c002f209cdc12cae1a1fec926493cd2262efe37dc6b25a30cea863",
+                "sha256:fc657577f057d60dd3642c9f95f28b432889b73143140061f7c1331d02f03df6",
+                "sha256:fcb90592c5d5c562e1b1a1ceccf6f00036d73c51db0271bf4d352b8d6b31d468",
+                "sha256:fe73d7c89d6f803bed122135ff5783364e8cdb479cf6fe2d764a44b6349e7e0f",
+                "sha256:ffecc43b3c18e36b62fcec995761829b6ac325d8dd74a4f2c5c1653afbb4495a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==26.1.0"
+            "version": "==26.1.1"
         },
         "redis": {
             "hashes": [
@@ -2759,6 +2766,9 @@
             "version": "==12.6.0"
         },
         "sentry-sdk": {
+            "extras": [
+                "flask"
+            ],
             "hashes": [
                 "sha256:608887855ccfe39032bfd03936e3a1c4f4fc99b3a4ac49ced54a4220de61c9c1",
                 "sha256:a16c997c0f4e3df63c0fc5e4207ccb1ab37900433e0f72fef88315d317829a26"
@@ -2768,11 +2778,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:80aacbf633704e9c8bfa1d99fa5dd4dc59573efcf9e4042c13d3bcef91ac2ef9",
-                "sha256:f11dd94b7bae3a156a95ec151f24e4637fb4fa19c878e4d191bfb8b2d82728c4"
+                "sha256:b208925fcb9f7af924ed2dc04708ea89791e24bde0d3020b27df0e116088b34e",
+                "sha256:d59a3e788ab7e012ab2c4baed1b376da6366883ee20d7a5fc426816e3d7b1193"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==72.2.0"
+            "version": "==73.0.1"
         },
         "simplejson": {
             "hashes": [
@@ -3184,11 +3194,11 @@
         },
         "types-python-dateutil": {
             "hashes": [
-                "sha256:5d2f2e240b86905e40944dd787db6da9263f0deabef1076ddaed797351ec0202",
-                "sha256:6b8cb66d960771ce5ff974e9dd45e38facb81718cc1e208b10b1baccbfdbee3b"
+                "sha256:9649d1dcb6fef1046fb18bebe9ea2aa0028b160918518c34589a46045f6ebd98",
+                "sha256:f5889fcb4e63ed4aaa379b44f93c32593d50b9a94c9a60a0c854d8cc3511cd57"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.9.0.20240316"
+            "version": "==2.9.0.20240821"
         },
         "types-pyyaml": {
             "hashes": [
@@ -3496,11 +3506,11 @@
             "version": "==3.0.0"
         },
         "zenodo-legacy": {
-            "editable": true,
+            "editable": "True",
             "path": "./legacy"
         },
         "zenodo-rdm": {
-            "editable": true,
+            "editable": "True",
             "path": "./site"
         },
         "zipp": {
@@ -3702,6 +3712,9 @@
             "version": "==8.1.7"
         },
         "coverage": {
+            "extras": [
+                "toml"
+            ],
             "hashes": [
                 "sha256:06a737c882bd26d0d6ee7269b20b12f14a8704807a01056c80bb881a4b2ce6ca",
                 "sha256:07e2ca0ad381b91350c0ed49d52699b625aab2b44b65e1b4e02fa9df0e92ad2d",
@@ -3821,19 +3834,19 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:11901fa0c2f97919b288679932bb64febaeacf289d18ac84dd68cb2e74213369",
-                "sha256:72e8d4399996132204f9a16dcc751af254a48f8d1b20b9ff0f98d4a8f901e73d"
+                "sha256:66f342cc6ac9818fc6ff340576acd24d65ba0b3efabb2b4ac08b598965a4a2f1",
+                "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==8.2.0"
+            "version": "==8.4.0"
         },
         "importlib-resources": {
             "hashes": [
-                "sha256:6cbfbefc449cc6e2095dd184691b7a12a04f40bc75dd4c55d31c34f174cdf57a",
-                "sha256:8bba8c54a8a3afaa1419910845fa26ebd706dc716dd208d9b158b4b6966f5c5c"
+                "sha256:2d6dfe3b9e055f72495c2085890837fc8c758984e209115c8792bddcb762cd93",
+                "sha256:4a202b9b9d38563b46da59221d77bb73862ab5d79d461307bcb826d725448b98"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==6.4.2"
+            "version": "==6.4.3"
         },
         "iniconfig": {
             "hashes": [
@@ -3849,6 +3862,7 @@
                 "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.8.0'",
             "version": "==5.13.2"
         },
         "itsdangerous": {
@@ -4026,6 +4040,7 @@
                 "sha256:1d339b004f764d6cd0f06e690f6dd748df3d62e6fe1a692d6a5500ac2c5b75a5"
             ],
             "index": "pypi",
+            "markers": "python_version >= '2.7'",
             "version": "==0.3.12"
         },
         "pytest-cov": {
@@ -4058,6 +4073,7 @@
                 "sha256:b759a791c94fc79d811ad74acf795fa3b5b1293a0cd852527d537d7d40f9a180"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.2.1"
         },
         "pytest-isort": {
@@ -4099,11 +4115,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:80aacbf633704e9c8bfa1d99fa5dd4dc59573efcf9e4042c13d3bcef91ac2ef9",
-                "sha256:f11dd94b7bae3a156a95ec151f24e4637fb4fa19c878e4d191bfb8b2d82728c4"
+                "sha256:b208925fcb9f7af924ed2dc04708ea89791e24bde0d3020b27df0e116088b34e",
+                "sha256:d59a3e788ab7e012ab2c4baed1b376da6366883ee20d7a5fc426816e3d7b1193"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==72.2.0"
+            "version": "==73.0.1"
         },
         "snowballstemmer": {
             "hashes": [


### PR DESCRIPTION
📁 invenio-communities (14.5.2 -> 14.5.3 🐛)

    📦 release: v14.5.3
    http headers: use and adjust vnd.inveniordm.v1+json http accept header

    * closes https://github.com/zenodo/rdm-project/issues/598

📁 invenio-rdm-records (11.6.0 -> 11.8.0 🌈)

    📦 release: v11.8.0
    pids: fix parent DOI link generation
    schemaorg: add dateCreated field

    * Closes inveniosoftware/invenio-rdm-records#1777.
    i18n:push translations
    assets: add package-lock.json for translations
    package: bump react-invenio-forms
    js: fix jest missing globals
    ci: use reusable workflows
    subjects: remove suggest from dropdown if not required

    * closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2767
    release: v11.7.0
    http headers: use and adjust vnd.inveniordm.v1+json http accept header

    * closes https://github.com/zenodo/rdm-project/issues/598
    transifex: update file path for ui strings

📁 invenio-vocabularies (4.4.0 -> 4.5.0 🌈)

    📦 release: v4.5.0
    ror: fix dump modified date comparison
    subjects: minor fixes
    subjects: mesh: add mesh subject datastreams
    subjects: datastream: remove system identity from writer
    subjects: remove YAMLTransformer; add pre_load subject
    add missing required field to tests
    made the subject field required as before
    change schema of subject: add text and synonyms
    switch to datastreams
    package: bump react-invenio-forms
    i18n:push translations