### PR TITLE
index_templates: configure number of shards for record indices

### DIFF
--- a/site/setup.cfg
+++ b/site/setup.cfg
@@ -81,6 +81,8 @@ invenio_access.actions =
     manage_external_doi_files_action = zenodo_rdm.generators:manage_external_doi_files_action
 invenio_previewer.previewers =
     image_previewer = zenodo_rdm.previewer.image_previewer
+invenio_search.index_templates =
+    zenodo_rdm = zenodo_rdm.index_templates
 
 [bdist_wheel]
 universal = 1

--- a/site/zenodo_rdm/index_templates/__init__.py
+++ b/site/zenodo_rdm/index_templates/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# ZenodoRDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Zenodo RDM index templates."""

--- a/site/zenodo_rdm/index_templates/os-v2/__init__.py
+++ b/site/zenodo_rdm/index_templates/os-v2/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# ZenodoRDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Zenodo RDM index templates."""

--- a/site/zenodo_rdm/index_templates/os-v2/rdmrecords-template.json
+++ b/site/zenodo_rdm/index_templates/os-v2/rdmrecords-template.json
@@ -1,0 +1,9 @@
+{
+  "priority": 100,
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__rdmrecords-*"],
+  "template": {
+    "settings": {
+        "number_of_shards": 3
+    }
+  }
+}


### PR DESCRIPTION
This is to make sure that records and drafts indices are created with 3 shards.