### PR TITLE
openaire: fix direct index deletion calls

### DIFF
--- a/site/zenodo_rdm/openaire/config.py
+++ b/site/zenodo_rdm/openaire/config.py
@@ -5,7 +5,7 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 """OpenAire related configs."""
 
-OPENAIRE_API_URL = "http://dev.openaire.research-infrastructures.eu/is/mvc/api/results"
+OPENAIRE_API_URL = "http://dev.openaire.research-infrastructures.eu/is/mvc/api"
 """OpenAIRE API endpoint."""
 
 OPENAIRE_API_CREDENTIALS = {"username": "CHANGE_ME", "password": "CHANGE_ME"}

--- a/site/zenodo_rdm/openaire/utils.py
+++ b/site/zenodo_rdm/openaire/utils.py
@@ -6,6 +6,7 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 """OpenAire related helpers."""
 
+import hashlib
 import urllib
 
 from flask import current_app
@@ -119,6 +120,13 @@ def openaire_original_id(record):
 def openaire_datasource_id(record):
     """Get OpenAIRE datasource identifier."""
     return OPENAIRE_ZENODO_IDS.get(openaire_type(record))
+
+
+def get_openaire_id(record):
+    """Compute OpenAIRE identifier."""
+    doi = record.get("pids", {}).get("doi", {}).get("identifier")
+    doi_hash = hashlib.md5(doi.encode()).hexdigest()
+    return f"doi_________::{doi_hash}"
 
 
 def openaire_request_factory(headers=None, auth=None):


### PR DESCRIPTION
* Switches to the alternative "/api/result/{openaire_id}" OpenAIRE endpoint, which can be used when only knowing the DOI of a record.
* Adjust task retry time window to 10min since maximum time is 15min.
* Instead of failling completely, only log failed requests to OpenAIRE beta instance.
* Closes #1022.