### PR TITLE
 horizon: frontpage: disable autofocus on CommunitySelectionSearch & bring back projects to frontpage

### DIFF
--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/horizon/index.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/horizon/index.js
@@ -37,6 +37,7 @@ ReactDOM.render(
     isInitialSubmission={defaultProps.isInitialSubmission}
     CommunityListItem={CommunityItem}
     pagination={false}
+    autofocus={false}
   />,
   document.getElementById("project-search-menu")
 );

--- a/templates/themes/horizon/invenio_communities/details/home/index.html
+++ b/templates/themes/horizon/invenio_communities/details/home/index.html
@@ -100,10 +100,10 @@
         </div>
         <div class="ui divider ml-0"></div>
         <div class="ui wide stretched stackable three column grid rel-mt-3">
-          <div class="sixteen wide mobile sixteen wide tablet eight wide computer column">
+          <div class="sixteen wide mobile sixteen wide tablet five wide computer column">
             <div class="segment-container rel-p-1 rel-pl-2 rel-pr-2">
                 <h1 class="center aligned ui medium header rel-m-1">{{ _("Subject areas") }} </h1>
-                <div class="ui bottom attached">
+                <div class="ui bottom attached"> 
                   {% set subjects = collections.values() | selectattr('slug', 'equalto', 'subjects') | first %}
                   {% for collection in subjects.collections %}
                     {{ render_depth_one_collection(community, subjects, collection) }}
@@ -117,7 +117,7 @@
                 </div>
             </div>
           </div>
-          {# <div class="sixteen wide mobile sixteen wide tablet six wide computer  column">
+          <div class="sixteen wide mobile sixteen wide tablet six wide computer  column">
             <div class="segment-container rel-p-1">
                 <h1 class="center aligned ui medium header rel-m-1">{{ _("Projects") }} </h1>
                 <div class="ui bottom attached">
@@ -131,8 +131,8 @@
                   </div>
                 </div>
             </div>
-          </div> #}
-          <div class="sixteen wide mobile sixteen wide tablet eight wide computer column">
+          </div>
+          <div class="sixteen wide mobile sixteen wide tablet five wide computer column">
             <div class="segment-container rel-p-1 rel-pl-2 rel-pr-2">
                 <h1 class="center aligned ui medium header rel-m-1">{{ _("Funding programmes") }} </h1>
                 <div class="ui bottom attached">


### PR DESCRIPTION
Partially closes inveniosoftware/invenio-communities#1227
Depends on inveniosoftware/invenio-rdm-records#1848

### Description

The "Search in all communities" input in the community front page is currently auto-focused (see linked issue).
While it makes sense for the auto-focus to be present in a model, it does not in a community front page where this is not the only input and it is lower in the page.