### PR TITLE
horizon: frontpage: disable My communities for unauthenticated users on CommunitySelectionSearch

### DIFF
--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/horizon/index.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/horizon/index.js
@@ -3,6 +3,9 @@ import ReactDOM from "react-dom";
 import { CommunityItem } from "./community-item";
 import { CommunitySelectionSearch } from "@js/invenio_rdm_records";
 
+const projectSearchContainer = document.getElementById("project-search-menu");
+const isUserAuthenticated = JSON.parse(projectSearchContainer.dataset.isAuthenticated);
+
 const defaultProps = {
   isInitialSubmission: true,
   apiConfigs: {
@@ -37,7 +40,8 @@ ReactDOM.render(
     isInitialSubmission={defaultProps.isInitialSubmission}
     CommunityListItem={CommunityItem}
     pagination={false}
+    myCommunitiesEnabled={isUserAuthenticated}
     autofocus={false}
   />,
-  document.getElementById("project-search-menu")
+  projectSearchContainer
 );

--- a/templates/themes/horizon/invenio_communities/details/home/index.html
+++ b/templates/themes/horizon/invenio_communities/details/home/index.html
@@ -121,7 +121,11 @@
             <div class="segment-container rel-p-1">
                 <h1 class="center aligned ui medium header rel-m-1">{{ _("Projects") }} </h1>
                 <div class="ui bottom attached">
-                  <div id="project-search-menu" class="rel-p-1">
+                  {%- set is_user_authenticated = current_user.is_authenticated %}
+                  <div
+                    id="project-search-menu"
+                    data-is-authenticated='{{ is_user_authenticated | tojson }}'
+                    class="rel-p-1">
                   </div>
                   <div class="ui container center aligned rel-mb-1">
                     <a href="{{ url_for('invenio_communities.communities_subcommunities', pid_value=community.slug) }}"


### PR DESCRIPTION
Partially fixes inveniosoftware/invenio-communities#1227
Depends on inveniosoftware/invenio-rdm-records#1850

Now that the `CommunitySelectionSearch` is used in the community front page (see linked issue), there might not be an authenticated user and the myCommunities tab might not make sense.
Here we are disabled `myCommunities` if the user is not authenticated.