### PR TITLE
installation: bump dependencies

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -80,11 +80,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346",
-                "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"
+                "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff",
+                "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==24.2.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.3.0"
         },
         "babel": {
             "hashes": [
@@ -180,11 +180,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
-                "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"
+                "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
+                "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.8.30"
+            "version": "==2024.12.14"
         },
         "cffi": {
             "hashes": [
@@ -1245,11 +1245,11 @@
         },
         "invenio-rdm-records": {
             "hashes": [
-                "sha256:324276a1cedc68b4043c34140d263981ba2d733ceeab4d229d9202da697461cc",
-                "sha256:72609acbf62c1bb13c00ad3624c82ae89ec1328a045ef93132711f8b509d0698"
+                "sha256:a0182ec0f7029bf1fc5428f45acf5cf962bb952170efae5fd65078ee9ac96743",
+                "sha256:a8cde6f107a97a549144afd22bda495afc2c61bd46a867dff3bcde860d0aaf6a"
             ],
             "index": "pypi",
-            "version": "==16.4.1"
+            "version": "==16.4.2"
         },
         "invenio-records": {
             "hashes": [
@@ -3624,11 +3624,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346",
-                "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"
+                "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff",
+                "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==24.2.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.3.0"
         },
         "babel": {
             "hashes": [
@@ -3663,7 +3663,7 @@
                 "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50",
                 "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"
             ],
-            "markers": "python_version >= '3.9'",
+            "markers": "python_version >= '3.6'",
             "version": "==24.10.0"
         },
         "build": {
@@ -3676,11 +3676,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
-                "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"
+                "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
+                "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.8.30"
+            "version": "==2024.12.14"
         },
         "charset-normalizer": {
             "hashes": [
@@ -4122,10 +4122,11 @@
         },
         "pytest-black": {
             "hashes": [
-                "sha256:1d339b004f764d6cd0f06e690f6dd748df3d62e6fe1a692d6a5500ac2c5b75a5"
+                "sha256:7eb747f54b6c997497b5cbc66a988be114b92016dbfa66d210d1d1f9f6b2dc76",
+                "sha256:ecb77455f379805cb4bd8f45a813a3754c3bbee3199adf1b3665c0dfd086b511"
             ],
             "index": "pypi",
-            "version": "==0.3.12"
+            "version": "==0.6.0"
         },
         "pytest-cov": {
             "hashes": [


### PR DESCRIPTION
📁 invenio-rdm-records (16.4.1 -> 16.4.2 🐛)

    📦 release: v16.4.2
    rights: fix serialize condition for controlled license
