### PR TITLE
Consistent capitalisation and remove invalid attribute

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/frontpage.html
+++ b/templates/semantic-ui/zenodo_rdm/frontpage.html
@@ -48,25 +48,25 @@
     <div class="ui segment bottom attached rdm-sidebar">
       <ul class="m-0">
         <li>
-          <strong>Safe</strong> — your research is stored safely for the future in CERN’s Data Centre for as long as CERN exists.
+          <strong>Safe</strong> — Your research is stored safely for the future in CERN’s Data Centre for as long as CERN exists
         </li>
         <li>
-          <strong>Trusted</strong> — built and operated by CERN and OpenAIRE to ensure that everyone can join in Open Science.
+          <strong>Trusted</strong> — Built and operated by CERN and OpenAIRE to ensure that everyone can join in Open Science
         </li>
         <li>
-          <strong>Citeable</strong> — every upload is assigned a Digital Object Identifier (DOI), to make them citable and trackable.
+          <strong>Citeable</strong> — Every upload is assigned a Digital Object Identifier (DOI), to make them citable and trackable
         </li>
         <li>
-          <strong>No waiting time</strong> — Uploads are made available online as soon as you hit publish, and your DOI is registered within seconds.
+          <strong>No waiting time</strong> — Uploads are made available online as soon as you hit publish, and your DOI is registered within seconds
         </li>
         <li>
-          <strong>Open or closed</strong> — Share e.g. anonymized clinical trial data with only medical professionals via our restricted access mode.
+         <strong>Open or closed</strong> — Share e.g. anonymized clinical trial data with only medical professionals via our restricted access mode
         </li>
         <li>
-          <strong>Versioning</strong> — Easily update your dataset with our versioning feature.
+          <strong>Versioning</strong> — Easily update your dataset with our versioning feature
         </li>
         <li>
-          <strong>GitHub integration</strong> — Easily preserve your GitHub repository in Zenodo.
+          <strong>GitHub integration</strong> — Easily preserve your GitHub repository in Zenodo
         </li>
         <li>
           <strong>Usage statistics</strong> — All uploads display standards compliant usage statistics
@@ -96,7 +96,7 @@
           <input id="newsletter-name" type="text" name="name" placeholder="Your name">
         </div>
 
-        <input id="e7755" type="hidden" name="l" checked="" value="e775524d-5cce-4885-b559-ef0f6214f24b">
+        <input id="e7755" type="hidden" name="l" value="e775524d-5cce-4885-b559-ef0f6214f24b">
         <input type="submit" value="Subscribe" class="ui primary button fluid">
       </form>
     </div>


### PR DESCRIPTION
1. Capitalised the first word always after —
2. Removed full stop at end of sentence as it is unnecessary
3. I know I shouldn't put this in the same PR (I used the web UI sorry), but removed the `checked` attributed as it is invalid on `type=hidden` elements. I did test that you can still subscribe to the mailing list when `checked` is removed

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/8139442d-07af-42e9-86ac-bc061fd8960c" />
