### PR TITLE
flask v3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,18 +4,18 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pytest-invenio = ">=2.1.0,<3.0.0"
-pytest-black = ">=0.3.0"
+pytest-invenio = ">=3.0.0,<4.0.0"
+pytest-black = ">=0.4.0"
 sphinx = ">=4.5"
-isort = "<6.0" # Unpin when isort==6.0.0 is released
+isort = ">=6.0"
 
 [packages]
-invenio-app-rdm = {version = "==13.0.0b2.dev1", extras = ["opensearch2"]}
+invenio-app-rdm = {version = "==13.0.0b2.dev2", extras = ["opensearch2"]}
 sentry-sdk = ">=1.45,<2.0.0"
 zenodo_rdm = {editable="True", path="./site"}
 zenodo_legacy = {editable="True", path="./legacy"}
 # TODO: Remove once we fix PyPI package issues
-invenio-swh = {git = "https://github.com/inveniosoftware/invenio-swh", ref = "v0.13.0"}
+invenio-swh = {git = "https://github.com/inveniosoftware/invenio-swh", ref = "v0.13.1"}
 jsonschema = ">=4.17.0,<4.18.0" # due to compatibility issues with alpha
 ipython = "!=8.1.0"
 pyuwsgi = ">=2.0"

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ sphinx = ">=4.5"
 isort = "<6.0" # Unpin when isort==6.0.0 is released
 
 [packages]
-invenio-app-rdm = {version = "==13.0.0b2.dev0", extras = ["opensearch2"]}
+invenio-app-rdm = {version = "==13.0.0b2.dev1", extras = ["opensearch2"]}
 sentry-sdk = ">=1.45,<2.0.0"
 zenodo_rdm = {editable="True", path="./site"}
 zenodo_legacy = {editable="True", path="./legacy"}

--- a/Pipfile
+++ b/Pipfile
@@ -10,20 +10,18 @@ sphinx = ">=4.5"
 isort = "<6.0" # Unpin when isort==6.0.0 is released
 
 [packages]
-invenio-app-rdm = {version = "==13.0.0b1.dev28", extras = ["opensearch2"]}
+invenio-app-rdm = {version = "==13.0.0b2.dev0", extras = ["opensearch2"]}
 sentry-sdk = ">=1.45,<2.0.0"
 zenodo_rdm = {editable="True", path="./site"}
 zenodo_legacy = {editable="True", path="./legacy"}
 # TODO: Remove once we fix PyPI package issues
-invenio-swh = {git = "https://github.com/inveniosoftware/invenio-swh", ref = "v0.12.0"}
+invenio-swh = {git = "https://github.com/inveniosoftware/invenio-swh", ref = "v0.13.0"}
 jsonschema = ">=4.17.0,<4.18.0" # due to compatibility issues with alpha
 ipython = "!=8.1.0"
-uwsgi = ">=2.0"
+pyuwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"
 pyvips = ">=2.2.2,<3.0.0"
-# TODO: Remove once all packages are compatible with wtforms 3.2+
-wtforms = "<3.0.0"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -80,19 +80,19 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff",
-                "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"
+                "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e",
+                "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.3.0"
+            "version": "==25.1.0"
         },
         "babel": {
             "hashes": [
-                "sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b",
-                "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"
+                "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d",
+                "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.16.0"
+            "version": "==2.17.0"
         },
         "babel-edtf": {
             "hashes": [
@@ -110,11 +110,11 @@
         },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051",
-                "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed"
+                "sha256:1bd32405dacc920b42b83ba01644747ed77456a65760e285fbc47633ceddaf8b",
+                "sha256:99045d7d3f08f91f0d656bc9b7efbae189426cd913d830294a15eefa0ea4df16"
             ],
-            "markers": "python_full_version >= '3.6.0'",
-            "version": "==4.12.3"
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==4.13.3"
         },
         "bibtexparser": {
             "hashes": [
@@ -180,11 +180,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
-                "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"
+                "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651",
+                "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.12.14"
+            "version": "==2025.1.31"
         },
         "cffi": {
             "hashes": [
@@ -514,11 +514,11 @@
         },
         "deprecated": {
             "hashes": [
-                "sha256:353bc4a8ac4bfc96800ddab349d89c25dec1079f65fd53acdcc1e0b975b21320",
-                "sha256:683e561a90de76239796e6b6feac66b99030d2dd3fcf61ef996330f14bbb9b0d"
+                "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d",
+                "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.2.15"
+            "version": "==1.2.18"
         },
         "dictdiffer": {
             "hashes": [
@@ -590,11 +590,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:42f2da8cf561e38c72b25e9891168b1e25fec42b6b0b5b0b6cd6041da54af885",
-                "sha256:926d2301787220e0554c2e39afc4dc535ce4b0a8d0a089657137999f66334ef4"
+                "sha256:28c24061780f83b45d9cb15a72b8f143b09d276c9ff52eb557744b7a89e8ba19",
+                "sha256:609abe555761ff31b0e5e16f958696e9b65c9224a7ac612ac96bfc2b8f09fe35"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==35.0.0"
+            "version": "==35.2.0"
         },
         "fastjsonschema": {
             "hashes": [
@@ -704,11 +704,11 @@
         },
         "flask-oauthlib-invenio": {
             "hashes": [
-                "sha256:1258a40ea8ad92f45f1bc69c81439718528e0be6fd829326d7a02cd12b858d9d",
-                "sha256:676557441504831bae028a925a47af267fd8d743185655785a99b61962ce3792"
+                "sha256:b5dcba517a3c96b8b9b3d32e18deabbad8b9b547ad82f3e08657f67642abd5dd",
+                "sha256:eefbf34545d4a1194ff7f639f1c4991278955d9a1fcc1dbc89641a197d274f3b"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.1.1"
+            "version": "==1.1.2"
         },
         "flask-principal": {
             "hashes": [
@@ -995,11 +995,11 @@
         },
         "invenio-administration": {
             "hashes": [
-                "sha256:c397883e00af3667e4123f2ae89b5bcee86a3c65c433e3fa4c5cabc783f78ed7",
-                "sha256:d7872a38f258cb858b3d2c20245df81a88ba2df5573bfbaea391e54ba5540e90"
+                "sha256:397313cf8d855ed9bc7eb1c3e67f528cc1b592274ca75bab348601f3abcd111b",
+                "sha256:57bb700afbb9e38048c8013c0c61ccac528a22b8337077c3ca8f30b9ac28d2bf"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.0.0"
+            "version": "==3.1.0"
         },
         "invenio-app": {
             "hashes": [
@@ -1158,11 +1158,11 @@
         },
         "invenio-mail": {
             "hashes": [
-                "sha256:171e4c31ad78bea483debc102408732125a68379521b8cb672fb4c143817d45d",
-                "sha256:50fcc9e48aed84cb039dfb235d2f13f755aacffbc99433665759e3115184566e"
+                "sha256:80f5446880421189cf69e80cf1a654f651d3f597cdd8411ee136550e565dcdb0",
+                "sha256:893d57c34e2591cf08cb458cff005ec0c67868708fb1fef144ac589dca28ff1d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.2.0"
+            "version": "==2.2.1"
         },
         "invenio-notifications": {
             "hashes": [
@@ -1182,11 +1182,11 @@
         },
         "invenio-oauth2server": {
             "hashes": [
-                "sha256:0be042880fd848b884515db88fa084c7c97ec87a7d8ddb489c7d4917741afba8",
-                "sha256:8bfbf3f56bf3908d1ed9d99b90a2336efaf1a61378b37fa2f291043ce1e05837"
+                "sha256:9308657cce6bae1f659b6e8f5e3e6cd2f299d385f58fab939618f05e3087913b",
+                "sha256:a204c776f4714b777491f16ee5cfbe172b6fb0f9c025a68b0343f2114c551758"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.0.0"
+            "version": "==3.0.2"
         },
         "invenio-oauthclient": {
             "hashes": [
@@ -1261,11 +1261,11 @@
         },
         "invenio-records-resources": {
             "hashes": [
-                "sha256:aabecaed42c6f432f21f2c8d8fc2c4bee57930ab3423b7b2544fa01d84da38e7",
-                "sha256:fabad4b375a03e433c244bbeab482abab203187f7cef30a841b1c5504e6c4f1d"
+                "sha256:54e70433892c0b6f83cbdeb708f09c3d6ac743ebb09e90ccbf4e2fd1754b1f36",
+                "sha256:c402c0d56ab3a318ca3031ef1d2fe2e46db8c4568b71c895a9ce3fd58b6d11d6"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.0.0"
+            "version": "==7.0.1"
         },
         "invenio-records-rest": {
             "hashes": [
@@ -1617,11 +1617,11 @@
         },
         "mako": {
             "hashes": [
-                "sha256:42f48953c7eb91332040ff567eb7eea69b22e7a4affbc5ba8e845e8f730f6627",
-                "sha256:577b97e414580d3e088d47c2dbbe9594aa7a5146ed2875d4dfa9075af2dd3cc8"
+                "sha256:95920acccb578427a9aa38e37a186b1e43156c87260d7ba18ca63aa4c7cbd3a1",
+                "sha256:b5d65ff3462870feec922dbccf38f6efb44e5714d7b593a656be86663d8600ac"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.3.8"
+            "version": "==1.3.9"
         },
         "markdown": {
             "hashes": [
@@ -1700,11 +1700,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:1287bca04e6a5f4094822ac153c03da5e214a0a60bcd557b140f3e66991b8ca1",
-                "sha256:eb36762a1cc76d7abf831e18a3a1b26d3d481bbc74581b8e532a3d3a8115e1cb"
+                "sha256:3350409f20a70a7e4e11a27661187b77cdcaeb20abca41c1454fe33636bea09c",
+                "sha256:e6d8affb6cb61d39d26402096dc0aee12d5a26d490a121f118d2e81dc0719dc6"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.26.0"
+            "version": "==3.26.1"
         },
         "marshmallow-oneofschema": {
             "hashes": [
@@ -1831,11 +1831,11 @@
         },
         "mistune": {
             "hashes": [
-                "sha256:b05198cf6d671b3deba6c87ec6cf0d4eb7b72c524636eddb6dbf13823b52cee1",
-                "sha256:dbcac2f78292b9dc066cd03b7a3a26b62d85f8159f2ea5fd28e55df79908d667"
+                "sha256:02106ac2aa4f66e769debbfa028509a275069dcffce0dfa578edd7b991ee700a",
+                "sha256:e0740d635f515119f7d1feb6f9b192ee60f0cc649f80a8f944f905706a21654c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "mkdocs": {
             "hashes": [
@@ -1963,11 +1963,11 @@
         },
         "nbconvert": {
             "hashes": [
-                "sha256:c83467bb5777fdfaac5ebbb8e864f300b277f68692ecc04d6dab72f2d8442344",
-                "sha256:e12eac052d6fd03040af4166c563d76e7aeead2e9aadf5356db552a1784bd547"
+                "sha256:1375a7b67e0c2883678c48e506dc320febb57685e5ee67faa51b18a90f3a712b",
+                "sha256:576a7e37c6480da7b8465eefa66c17844243816ce1ccc372633c6b71c3c0f582"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.16.5"
+            "version": "==7.16.6"
         },
         "nbformat": {
             "hashes": [
@@ -2368,11 +2368,11 @@
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:637951cbfbe9874ba28134fb3ce4b8bcadd6aca89ac4998ec29dcbafd554ae08",
-                "sha256:b65801996a0cd4f42a3110810c306c45b7313c09b0610a6f773730f2a9e3c96b"
+                "sha256:05e0bee73d64b9c71a4ae17c72abc2f700e8bc8403755a00580b49a4e9f189e9",
+                "sha256:41e576ce3f5d650be59e900e4ceff231e0aed2a88cf30acaee41e02f063a061b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.14.1"
+            "version": "==10.14.3"
         },
         "pymysql": {
             "hashes": [
@@ -2610,118 +2610,118 @@
         },
         "pyzmq": {
             "hashes": [
-                "sha256:007137c9ac9ad5ea21e6ad97d3489af654381324d5d3ba614c323f60dab8fae6",
-                "sha256:034da5fc55d9f8da09015d368f519478a52675e558c989bfcb5cf6d4e16a7d2a",
-                "sha256:05590cdbc6b902101d0e65d6a4780af14dc22914cc6ab995d99b85af45362cc9",
-                "sha256:070672c258581c8e4f640b5159297580a9974b026043bd4ab0470be9ed324f1f",
-                "sha256:0aca98bc423eb7d153214b2df397c6421ba6373d3397b26c057af3c904452e37",
-                "sha256:0bed0e799e6120b9c32756203fb9dfe8ca2fb8467fed830c34c877e25638c3fc",
-                "sha256:0d987a3ae5a71c6226b203cfd298720e0086c7fe7c74f35fa8edddfbd6597eed",
-                "sha256:0eaa83fc4c1e271c24eaf8fb083cbccef8fde77ec8cd45f3c35a9a123e6da097",
-                "sha256:160c7e0a5eb178011e72892f99f918c04a131f36056d10d9c1afb223fc952c2d",
-                "sha256:17bf5a931c7f6618023cdacc7081f3f266aecb68ca692adac015c383a134ca52",
-                "sha256:17c412bad2eb9468e876f556eb4ee910e62d721d2c7a53c7fa31e643d35352e6",
-                "sha256:18c8dc3b7468d8b4bdf60ce9d7141897da103c7a4690157b32b60acb45e333e6",
-                "sha256:1a534f43bc738181aa7cbbaf48e3eca62c76453a40a746ab95d4b27b1111a7d2",
-                "sha256:1c17211bc037c7d88e85ed8b7d8f7e52db6dc8eca5590d162717c654550f7282",
-                "sha256:1f3496d76b89d9429a656293744ceca4d2ac2a10ae59b84c1da9b5165f429ad3",
-                "sha256:1fcc03fa4997c447dce58264e93b5aa2d57714fbe0f06c07b7785ae131512732",
-                "sha256:226af7dcb51fdb0109f0016449b357e182ea0ceb6b47dfb5999d569e5db161d5",
-                "sha256:23f4aad749d13698f3f7b64aad34f5fc02d6f20f05999eebc96b89b01262fb18",
-                "sha256:25bf2374a2a8433633c65ccb9553350d5e17e60c8eb4de4d92cc6bd60f01d306",
-                "sha256:28ad5233e9c3b52d76196c696e362508959741e1a005fb8fa03b51aea156088f",
-                "sha256:28c812d9757fe8acecc910c9ac9dafd2ce968c00f9e619db09e9f8f54c3a68a3",
-                "sha256:29c6a4635eef69d68a00321e12a7d2559fe2dfccfa8efae3ffb8e91cd0b36a8b",
-                "sha256:29c7947c594e105cb9e6c466bace8532dc1ca02d498684128b339799f5248277",
-                "sha256:2a50625acdc7801bc6f74698c5c583a491c61d73c6b7ea4dee3901bb99adb27a",
-                "sha256:2ae90ff9dad33a1cfe947d2c40cb9cb5e600d759ac4f0fd22616ce6540f72797",
-                "sha256:2c4a71d5d6e7b28a47a394c0471b7e77a0661e2d651e7ae91e0cab0a587859ca",
-                "sha256:2ea4ad4e6a12e454de05f2949d4beddb52460f3de7c8b9d5c46fbb7d7222e02c",
-                "sha256:2eb7735ee73ca1b0d71e0e67c3739c689067f055c764f73aac4cc8ecf958ee3f",
-                "sha256:31507f7b47cc1ead1f6e86927f8ebb196a0bab043f6345ce070f412a59bf87b5",
-                "sha256:35cffef589bcdc587d06f9149f8d5e9e8859920a071df5a2671de2213bef592a",
-                "sha256:367b4f689786fca726ef7a6c5ba606958b145b9340a5e4808132cc65759abd44",
-                "sha256:39887ac397ff35b7b775db7201095fc6310a35fdbae85bac4523f7eb3b840e20",
-                "sha256:3a495b30fc91db2db25120df5847d9833af237546fd59170701acd816ccc01c4",
-                "sha256:3b55a4229ce5da9497dd0452b914556ae58e96a4381bb6f59f1305dfd7e53fc8",
-                "sha256:402b190912935d3db15b03e8f7485812db350d271b284ded2b80d2e5704be780",
-                "sha256:43a47408ac52647dfabbc66a25b05b6a61700b5165807e3fbd40063fcaf46386",
-                "sha256:4661c88db4a9e0f958c8abc2b97472e23061f0bc737f6f6179d7a27024e1faa5",
-                "sha256:46a446c212e58456b23af260f3d9fb785054f3e3653dbf7279d8f2b5546b21c2",
-                "sha256:470d4a4f6d48fb34e92d768b4e8a5cc3780db0d69107abf1cd7ff734b9766eb0",
-                "sha256:49d34ab71db5a9c292a7644ce74190b1dd5a3475612eefb1f8be1d6961441971",
-                "sha256:4d29ab8592b6ad12ebbf92ac2ed2bedcfd1cec192d8e559e2e099f648570e19b",
-                "sha256:4d80b1dd99c1942f74ed608ddb38b181b87476c6a966a88a950c7dee118fdf50",
-                "sha256:4da04c48873a6abdd71811c5e163bd656ee1b957971db7f35140a2d573f6949c",
-                "sha256:4f78c88905461a9203eac9faac157a2a0dbba84a0fd09fd29315db27be40af9f",
-                "sha256:4ff9dc6bc1664bb9eec25cd17506ef6672d506115095411e237d571e92a58231",
-                "sha256:5506f06d7dc6ecf1efacb4a013b1f05071bb24b76350832c96449f4a2d95091c",
-                "sha256:55cf66647e49d4621a7e20c8d13511ef1fe1efbbccf670811864452487007e08",
-                "sha256:5a509df7d0a83a4b178d0f937ef14286659225ef4e8812e05580776c70e155d5",
-                "sha256:5c2b3bfd4b9689919db068ac6c9911f3fcb231c39f7dd30e3138be94896d18e6",
-                "sha256:6835dd60355593de10350394242b5757fbbd88b25287314316f266e24c61d073",
-                "sha256:689c5d781014956a4a6de61d74ba97b23547e431e9e7d64f27d4922ba96e9d6e",
-                "sha256:6a96179a24b14fa6428cbfc08641c779a53f8fcec43644030328f44034c7f1f4",
-                "sha256:6ace4f71f1900a548f48407fc9be59c6ba9d9aaf658c2eea6cf2779e72f9f317",
-                "sha256:6b274e0762c33c7471f1a7471d1a2085b1a35eba5cdc48d2ae319f28b6fc4de3",
-                "sha256:706e794564bec25819d21a41c31d4df2d48e1cc4b061e8d345d7fb4dd3e94072",
-                "sha256:70fc7fcf0410d16ebdda9b26cbd8bf8d803d220a7f3522e060a69a9c87bf7bad",
-                "sha256:7133d0a1677aec369d67dd78520d3fa96dd7f3dcec99d66c1762870e5ea1a50a",
-                "sha256:7445be39143a8aa4faec43b076e06944b8f9d0701b669df4af200531b21e40bb",
-                "sha256:76589c020680778f06b7e0b193f4b6dd66d470234a16e1df90329f5e14a171cd",
-                "sha256:76589f2cd6b77b5bdea4fca5992dc1c23389d68b18ccc26a53680ba2dc80ff2f",
-                "sha256:77eb0968da535cba0470a5165468b2cac7772cfb569977cff92e240f57e31bef",
-                "sha256:794a4562dcb374f7dbbfb3f51d28fb40123b5a2abadee7b4091f93054909add5",
-                "sha256:7ad1bc8d1b7a18497dda9600b12dc193c577beb391beae5cd2349184db40f187",
-                "sha256:7f98f6dfa8b8ccaf39163ce872bddacca38f6a67289116c8937a02e30bbe9711",
-                "sha256:8423c1877d72c041f2c263b1ec6e34360448decfb323fa8b94e85883043ef988",
-                "sha256:8685fa9c25ff00f550c1fec650430c4b71e4e48e8d852f7ddcf2e48308038640",
-                "sha256:878206a45202247781472a2d99df12a176fef806ca175799e1c6ad263510d57c",
-                "sha256:89289a5ee32ef6c439086184529ae060c741334b8970a6855ec0b6ad3ff28764",
-                "sha256:8ab5cad923cc95c87bffee098a27856c859bd5d0af31bd346035aa816b081fe1",
-                "sha256:8b435f2753621cd36e7c1762156815e21c985c72b19135dac43a7f4f31d28dd1",
-                "sha256:8be4700cd8bb02cc454f630dcdf7cfa99de96788b80c51b60fe2fe1dac480289",
-                "sha256:8c997098cc65e3208eca09303630e84d42718620e83b733d0fd69543a9cab9cb",
-                "sha256:8ea039387c10202ce304af74def5021e9adc6297067f3441d348d2b633e8166a",
-                "sha256:8f7e66c7113c684c2b3f1c83cdd3376103ee0ce4c49ff80a648643e57fb22218",
-                "sha256:90412f2db8c02a3864cbfc67db0e3dcdbda336acf1c469526d3e869394fe001c",
-                "sha256:92a78853d7280bffb93df0a4a6a2498cba10ee793cc8076ef797ef2f74d107cf",
-                "sha256:989d842dc06dc59feea09e58c74ca3e1678c812a4a8a2a419046d711031f69c7",
-                "sha256:9cb3a6460cdea8fe8194a76de8895707e61ded10ad0be97188cc8463ffa7e3a8",
-                "sha256:9dd8cd1aeb00775f527ec60022004d030ddc51d783d056e3e23e74e623e33726",
-                "sha256:9ed69074a610fad1c2fda66180e7b2edd4d31c53f2d1872bc2d1211563904cd9",
-                "sha256:9edda2df81daa129b25a39b86cb57dfdfe16f7ec15b42b19bfac503360d27a93",
-                "sha256:a2224fa4a4c2ee872886ed00a571f5e967c85e078e8e8c2530a2fb01b3309b88",
-                "sha256:a4f96f0d88accc3dbe4a9025f785ba830f968e21e3e2c6321ccdfc9aef755115",
-                "sha256:aedd5dd8692635813368e558a05266b995d3d020b23e49581ddd5bbe197a8ab6",
-                "sha256:aee22939bb6075e7afededabad1a56a905da0b3c4e3e0c45e75810ebe3a52672",
-                "sha256:b1d464cb8d72bfc1a3adc53305a63a8e0cac6bc8c5a07e8ca190ab8d3faa43c2",
-                "sha256:b8f86dd868d41bea9a5f873ee13bf5551c94cf6bc51baebc6f85075971fe6eea",
-                "sha256:bc6bee759a6bddea5db78d7dcd609397449cb2d2d6587f48f3ca613b19410cfc",
-                "sha256:bea2acdd8ea4275e1278350ced63da0b166421928276c7c8e3f9729d7402a57b",
-                "sha256:bfa832bfa540e5b5c27dcf5de5d82ebc431b82c453a43d141afb1e5d2de025fa",
-                "sha256:c0e6091b157d48cbe37bd67233318dbb53e1e6327d6fc3bb284afd585d141003",
-                "sha256:c3789bd5768ab5618ebf09cef6ec2b35fed88709b104351748a63045f0ff9797",
-                "sha256:c530e1eecd036ecc83c3407f77bb86feb79916d4a33d11394b8234f3bd35b940",
-                "sha256:c811cfcd6a9bf680236c40c6f617187515269ab2912f3d7e8c0174898e2519db",
-                "sha256:c92d73464b886931308ccc45b2744e5968cbaade0b1d6aeb40d8ab537765f5bc",
-                "sha256:cccba051221b916a4f5e538997c45d7d136a5646442b1231b916d0164067ea27",
-                "sha256:cdeabcff45d1c219636ee2e54d852262e5c2e085d6cb476d938aee8d921356b3",
-                "sha256:ced65e5a985398827cc9276b93ef6dfabe0273c23de8c7931339d7e141c2818e",
-                "sha256:d049df610ac811dcffdc147153b414147428567fbbc8be43bb8885f04db39d98",
-                "sha256:dacd995031a01d16eec825bf30802fceb2c3791ef24bcce48fa98ce40918c27b",
-                "sha256:ddf33d97d2f52d89f6e6e7ae66ee35a4d9ca6f36eda89c24591b0c40205a3629",
-                "sha256:ded0fc7d90fe93ae0b18059930086c51e640cdd3baebdc783a695c77f123dcd9",
-                "sha256:e3e0210287329272539eea617830a6a28161fbbd8a3271bf4150ae3e58c5d0e6",
-                "sha256:e6fa2e3e683f34aea77de8112f6483803c96a44fd726d7358b9888ae5bb394ec",
-                "sha256:ea0eb6af8a17fa272f7b98d7bebfab7836a0d62738e16ba380f440fceca2d951",
-                "sha256:ea7f69de383cb47522c9c208aec6dd17697db7875a4674c4af3f8cfdac0bdeae",
-                "sha256:eac5174677da084abf378739dbf4ad245661635f1600edd1221f150b165343f4",
-                "sha256:fc4f7a173a5609631bb0c42c23d12c49df3966f89f496a51d3eb0ec81f4519d6",
-                "sha256:fdb5b3e311d4d4b0eb8b3e8b4d1b0a512713ad7e6a68791d0923d1aec433d919"
+                "sha256:000760e374d6f9d1a3478a42ed0c98604de68c9e94507e5452951e598ebecfba",
+                "sha256:004837cb958988c75d8042f5dac19a881f3d9b3b75b2f574055e22573745f841",
+                "sha256:0250c94561f388db51fd0213cdccbd0b9ef50fd3c57ce1ac937bf3034d92d72e",
+                "sha256:03719e424150c6395b9513f53a5faadcc1ce4b92abdf68987f55900462ac7eec",
+                "sha256:0995fd3530f2e89d6b69a2202e340bbada3191014352af978fa795cb7a446331",
+                "sha256:099b56ef464bc355b14381f13355542e452619abb4c1e57a534b15a106bf8e23",
+                "sha256:09dac387ce62d69bec3f06d51610ca1d660e7849eb45f68e38e7f5cf1f49cbcb",
+                "sha256:0b2007f28ce1b8acebdf4812c1aab997a22e57d6a73b5f318b708ef9bcabbe95",
+                "sha256:0b6a93d684278ad865fc0b9e89fe33f6ea72d36da0e842143891278ff7fd89c3",
+                "sha256:0f50db737d688e96ad2a083ad2b453e22865e7e19c7f17d17df416e91ddf67eb",
+                "sha256:100a826a029c8ef3d77a1d4c97cbd6e867057b5806a7276f2bac1179f893d3bf",
+                "sha256:1238c2448c58b9c8d6565579393148414a42488a5f916b3f322742e561f6ae0d",
+                "sha256:160194d1034902937359c26ccfa4e276abffc94937e73add99d9471e9f555dd6",
+                "sha256:17d72a74e5e9ff3829deb72897a175333d3ef5b5413948cae3cf7ebf0b02ecca",
+                "sha256:17f88622b848805d3f6427ce1ad5a2aa3cf61f12a97e684dab2979802024d460",
+                "sha256:1c6ae0e95d0a4b0cfe30f648a18e764352d5415279bdf34424decb33e79935b8",
+                "sha256:1c84c1297ff9f1cd2440da4d57237cb74be21fdfe7d01a10810acba04e79371a",
+                "sha256:1fd4b3efc6f62199886440d5e27dd3ccbcb98dfddf330e7396f1ff421bfbb3c2",
+                "sha256:25e720dba5b3a3bb2ad0ad5d33440babd1b03438a7a5220511d0c8fa677e102e",
+                "sha256:269c14904da971cb5f013100d1aaedb27c0a246728c341d5d61ddd03f463f2f3",
+                "sha256:290c96f479504439b6129a94cefd67a174b68ace8a8e3f551b2239a64cfa131a",
+                "sha256:2d88ba221a07fc2c5581565f1d0fe8038c15711ae79b80d9462e080a1ac30435",
+                "sha256:2e1eb9d2bfdf5b4e21165b553a81b2c3bd5be06eeddcc4e08e9692156d21f1f6",
+                "sha256:31fff709fef3b991cfe7189d2cfe0c413a1d0e82800a182cfa0c2e3668cd450f",
+                "sha256:361edfa350e3be1f987e592e834594422338d7174364763b7d3de5b0995b16f3",
+                "sha256:36d4e7307db7c847fe37413f333027d31c11d5e6b3bacbb5022661ac635942ba",
+                "sha256:36ee4297d9e4b34b5dc1dd7ab5d5ea2cbba8511517ef44104d2915a917a56dc8",
+                "sha256:380816d298aed32b1a97b4973a4865ef3be402a2e760204509b52b6de79d755d",
+                "sha256:3ef584f13820d2629326fe20cc04069c21c5557d84c26e277cfa6235e523b10f",
+                "sha256:3fe6e28a8856aea808715f7a4fc11f682b9d29cac5d6262dd8fe4f98edc12d53",
+                "sha256:44dba28c34ce527cf687156c81f82bf1e51f047838d5964f6840fd87dfecf9fe",
+                "sha256:45fad32448fd214fbe60030aa92f97e64a7140b624290834cc9b27b3a11f9473",
+                "sha256:46d4ebafc27081a7f73a0f151d0c38d4291656aa134344ec1f3d0199ebfbb6d4",
+                "sha256:49135bb327fca159262d8fd14aa1f4a919fe071b04ed08db4c7c37d2f0647162",
+                "sha256:4a98898fdce380c51cc3e38ebc9aa33ae1e078193f4dc641c047f88b8c690c9a",
+                "sha256:4eb3197f694dfb0ee6af29ef14a35f30ae94ff67c02076eef8125e2d98963cd0",
+                "sha256:51431f6b2750eb9b9d2b2952d3cc9b15d0215e1b8f37b7a3239744d9b487325d",
+                "sha256:574b285150afdbf0a0424dddf7ef9a0d183988eb8d22feacb7160f7515e032cb",
+                "sha256:57dd4d91b38fa4348e237a9388b4423b24ce9c1695bbd4ba5a3eada491e09399",
+                "sha256:59660e15c797a3b7a571c39f8e0b62a1f385f98ae277dfe95ca7eaf05b5a0f12",
+                "sha256:5b4fc44f5360784cc02392f14235049665caaf7c0fe0b04d313e763d3338e463",
+                "sha256:632a09c6d8af17b678d84df442e9c3ad8e4949c109e48a72f805b22506c4afa7",
+                "sha256:637536c07d2fb6a354988b2dd1d00d02eb5dd443f4bbee021ba30881af1c28aa",
+                "sha256:651726f37fcbce9f8dd2a6dab0f024807929780621890a4dc0c75432636871be",
+                "sha256:6991ee6c43e0480deb1b45d0c7c2bac124a6540cba7db4c36345e8e092da47ce",
+                "sha256:6d75fcb00a1537f8b0c0bb05322bc7e35966148ffc3e0362f0369e44a4a1de99",
+                "sha256:70b3a46ecd9296e725ccafc17d732bfc3cdab850b54bd913f843a0a54dfb2c04",
+                "sha256:786dd8a81b969c2081b31b17b326d3a499ddd1856e06d6d79ad41011a25148da",
+                "sha256:7c6160fe513654e65665332740f63de29ce0d165e053c0c14a161fa60dd0da01",
+                "sha256:7ebdd96bd637fd426d60e86a29ec14b8c1ab64b8d972f6a020baf08a30d1cf46",
+                "sha256:7f18ce33f422d119b13c1363ed4cce245b342b2c5cbbb76753eabf6aa6f69c7d",
+                "sha256:80a00370a2ef2159c310e662c7c0f2d030f437f35f478bb8b2f70abd07e26b24",
+                "sha256:817fcd3344d2a0b28622722b98500ae9c8bfee0f825b8450932ff19c0b15bebd",
+                "sha256:8531ed35dfd1dd2af95f5d02afd6545e8650eedbf8c3d244a554cf47d8924459",
+                "sha256:866c12b7c90dd3a86983df7855c6f12f9407c8684db6aa3890fc8027462bda82",
+                "sha256:88812b3b257f80444a986b3596e5ea5c4d4ed4276d2b85c153a6fbc5ca457ae7",
+                "sha256:8b0f5bab40a16e708e78a0c6ee2425d27e1a5d8135c7a203b4e977cee37eb4aa",
+                "sha256:8bacc1a10c150d58e8a9ee2b2037a70f8d903107e0f0b6e079bf494f2d09c091",
+                "sha256:8ec8e3aea6146b761d6c57fcf8f81fcb19f187afecc19bf1701a48db9617a217",
+                "sha256:8eddb3784aed95d07065bcf94d07e8c04024fdb6b2386f08c197dfe6b3528fda",
+                "sha256:9027a7fcf690f1a3635dc9e55e38a0d6602dbbc0548935d08d46d2e7ec91f454",
+                "sha256:90dc731d8e3e91bcd456aa7407d2eba7ac6f7860e89f3766baabb521f2c1de4a",
+                "sha256:91e2bfb8e9a29f709d51b208dd5f441dc98eb412c8fe75c24ea464734ccdb48e",
+                "sha256:95f5728b367a042df146cec4340d75359ec6237beebf4a8f5cf74657c65b9257",
+                "sha256:95f7b01b3f275504011cf4cf21c6b885c8d627ce0867a7e83af1382ebab7b3ff",
+                "sha256:97cbb368fd0debdbeb6ba5966aa28e9a1ae3396c7386d15569a6ca4be4572b99",
+                "sha256:9ec6abfb701437142ce9544bd6a236addaf803a32628d2260eb3dbd9a60e2891",
+                "sha256:9fbdb90b85c7624c304f72ec7854659a3bd901e1c0ffb2363163779181edeb68",
+                "sha256:a003200b6cd64e89b5725ff7e284a93ab24fd54bbac8b4fa46b1ed57be693c27",
+                "sha256:a0741edbd0adfe5f30bba6c5223b78c131b5aa4a00a223d631e5ef36e26e6d13",
+                "sha256:a23948554c692df95daed595fdd3b76b420a4939d7a8a28d6d7dea9711878641",
+                "sha256:a4bffcadfd40660f26d1b3315a6029fd4f8f5bf31a74160b151f5c577b2dc81b",
+                "sha256:a6549ecb0041dafa55b5932dcbb6c68293e0bd5980b5b99f5ebb05f9a3b8a8f3",
+                "sha256:a7ad34a2921e8f76716dc7205c9bf46a53817e22b9eec2e8a3e08ee4f4a72468",
+                "sha256:abf7b5942c6b0dafcc2823ddd9154f419147e24f8df5b41ca8ea40a6db90615c",
+                "sha256:b314268e716487bfb86fcd6f84ebbe3e5bec5fac75fdf42bc7d90fdb33f618ad",
+                "sha256:baa1da72aecf6a490b51fba7a51f1ce298a1e0e86d0daef8265c8f8f9848eb77",
+                "sha256:bd8fdee945b877aa3bffc6a5a8816deb048dab0544f9df3731ecd0e54d8c84c9",
+                "sha256:bdbc78ae2065042de48a65f1421b8af6b76a0386bb487b41955818c3c1ce7bed",
+                "sha256:c059883840e634a21c5b31d9b9a0e2b48f991b94d60a811092bc37992715146a",
+                "sha256:c1bb37849e2294d519117dd99b613c5177934e5c04a5bb05dd573fa42026567e",
+                "sha256:c2a9cb17fd83b7a3a3009901aca828feaf20aa2451a8a487b035455a86549c09",
+                "sha256:c7154d228502e18f30f150b7ce94f0789d6b689f75261b623f0fdc1eec642aab",
+                "sha256:cdb69710e462a38e6039cf17259d328f86383a06c20482cc154327968712273c",
+                "sha256:ceb0d78b7ef106708a7e2c2914afe68efffc0051dc6a731b0dbacd8b4aee6d68",
+                "sha256:d14f50d61a89b0925e4d97a0beba6053eb98c426c5815d949a43544f05a0c7ec",
+                "sha256:d51a7bfe01a48e1064131f3416a5439872c533d756396be2b39e3977b41430f9",
+                "sha256:d9da0289d8201c8a29fd158aaa0dfe2f2e14a181fd45e2dc1fbf969a62c1d594",
+                "sha256:e5e33b1491555843ba98d5209439500556ef55b6ab635f3a01148545498355e5",
+                "sha256:e76ad4729c2f1cf74b6eb1bdd05f6aba6175999340bd51e6caee49a435a13bf5",
+                "sha256:e7eeaef81530d0b74ad0d29eec9997f1c9230c2f27242b8d17e0ee67662c8f6e",
+                "sha256:e8e47050412f0ad3a9b2287779758073cbf10e460d9f345002d4779e43bb0136",
+                "sha256:ed038a921df836d2f538e509a59cb638df3e70ca0fcd70d0bf389dfcdf784d2a",
+                "sha256:edb550616f567cd5603b53bb52a5f842c0171b78852e6fc7e392b02c2a1504bb",
+                "sha256:ee7152f32c88e0e1b5b17beb9f0e2b14454235795ef68c0c120b6d3d23d12833",
+                "sha256:eeb37f65350d5c5870517f02f8bbb2ac0fbec7b416c0f4875219fef305a89a45",
+                "sha256:ef29630fde6022471d287c15c0a2484aba188adbfb978702624ba7a54ddfa6c1",
+                "sha256:ef5479fac31df4b304e96400fc67ff08231873ee3537544aa08c30f9d22fce38",
+                "sha256:f0019cc804ac667fb8c8eaecdb66e6d4a68acf2e155d5c7d6381a5645bd93ae4",
+                "sha256:f0f19c2097fffb1d5b07893d75c9ee693e9cbc809235cf3f2267f0ef6b015f24",
+                "sha256:f19dae58b616ac56b96f2e2290f2d18730a898a171f447f491cc059b073ca1fa",
+                "sha256:f1f31661a80cc46aba381bed475a9135b213ba23ca7ff6797251af31510920ce",
+                "sha256:f2c307fbe86e18ab3c885b7e01de942145f539165c3360e2af0f094dd440acd9",
+                "sha256:f32718ee37c07932cc336096dc7403525301fd626349b6eff8470fe0f996d8d7",
+                "sha256:f39d1227e8256d19899d953e6e19ed2ccb689102e6d85e024da5acf410f301eb",
+                "sha256:f5eeeb82feec1fc5cbafa5ee9022e87ffdb3a8c48afa035b356fcd20fc7f533f",
+                "sha256:f92a002462154c176dac63a8f1f6582ab56eb394ef4914d65a9417f5d9fde218",
+                "sha256:f9ba5def063243793dec6603ad1392f735255cbc7202a3a484c14f99ec290705",
+                "sha256:fc409c18884eaf9ddde516d53af4f2db64a8bc7d81b1a0c274b8aa4e929958e8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==26.2.0"
+            "version": "==26.2.1"
         },
         "rdflib": {
             "hashes": [
@@ -3115,66 +3115,66 @@
                 "asyncio"
             ],
             "hashes": [
-                "sha256:03f0528c53ca0b67094c4764523c1451ea15959bbf0a8a8a3096900014db0278",
-                "sha256:12b0f1ec623cccf058cf21cb544f0e74656618165b083d78145cafde156ea7b6",
-                "sha256:12b28d99a9c14eaf4055810df1001557176716de0167b91026e648e65229bffb",
-                "sha256:1b2690456528a87234a75d1a1644cdb330a6926f455403c8e4f6cad6921f9098",
-                "sha256:1cdba1f73b64530c47b27118b7053b8447e6d6f3c8104e3ac59f3d40c33aa9fd",
-                "sha256:293f9ade06b2e68dd03cfb14d49202fac47b7bb94bffcff174568c951fbc7af2",
-                "sha256:2952748ecd67ed3b56773c185e85fc084f6bdcdec10e5032a7c25a6bc7d682ef",
-                "sha256:2f95fc8e3f34b5f6b3effb49d10ac97c569ec8e32f985612d9b25dd12d0d2e94",
-                "sha256:2fa2c0913f02341d25fb858e4fb2031e6b0813494cca1ba07d417674128ce11b",
-                "sha256:3151822aa1db0eb5afd65ccfafebe0ef5cda3a7701a279c8d0bf17781a793bb4",
-                "sha256:35bd2df269de082065d4b23ae08502a47255832cc3f17619a5cea92ce478b02b",
-                "sha256:41296bbcaa55ef5fdd32389a35c710133b097f7b2609d8218c0eabded43a1d84",
-                "sha256:44f569d0b1eb82301b92b72085583277316e7367e038d97c3a1a899d9a05e342",
-                "sha256:46954173612617a99a64aee103bcd3f078901b9a8dcfc6ae80cbf34ba23df989",
-                "sha256:4b12885dc85a2ab2b7d00995bac6d967bffa8594123b02ed21e8eb2205a7584b",
-                "sha256:4f581d365af9373a738c49e0c51e8b18e08d8a6b1b15cc556773bcd8a192fa8b",
-                "sha256:51bc9cfef83e0ac84f86bf2b10eaccb27c5a3e66a1212bef676f5bee6ef33ebb",
-                "sha256:521ef85c04c33009166777c77e76c8a676e2d8528dc83a57836b63ca9c69dcd1",
-                "sha256:5bc3339db84c5fb9130ac0e2f20347ee77b5dd2596ba327ce0d399752f4fce39",
-                "sha256:635d8a21577341dfe4f7fa59ec394b346da12420b86624a69e466d446de16aff",
-                "sha256:648ec5acf95ad59255452ef759054f2176849662af4521db6cb245263ae4aa33",
-                "sha256:650dcb70739957a492ad8acff65d099a9586b9b8920e3507ca61ec3ce650bb72",
-                "sha256:6b788f14c5bb91db7f468dcf76f8b64423660a05e57fe277d3f4fad7b9dcb7ce",
-                "sha256:6c67415258f9f3c69867ec02fea1bf6508153709ecbd731a982442a590f2b7e4",
-                "sha256:74bbd1d0a9bacf34266a7907d43260c8d65d31d691bb2356f41b17c2dca5b1d0",
-                "sha256:75311559f5c9881a9808eadbeb20ed8d8ba3f7225bef3afed2000c2a9f4d49b9",
-                "sha256:78361be6dc9073ed17ab380985d1e45e48a642313ab68ab6afa2457354ff692c",
-                "sha256:7b7e772dc4bc507fdec4ee20182f15bd60d2a84f1e087a8accf5b5b7a0dcf2ba",
-                "sha256:82df02816c14f8dc9f4d74aea4cb84a92f4b0620235daa76dde002409a3fbb5a",
-                "sha256:84b9f23b0fa98a6a4b99d73989350a94e4a4ec476b9a7dfe9b79ba5939f5e80b",
-                "sha256:8c4096727193762e72ce9437e2a86a110cf081241919ce3fab8e89c02f6b6658",
-                "sha256:8e47f1af09444f87c67b4f1bb6231e12ba6d4d9f03050d7fc88df6d075231a49",
-                "sha256:93d1543cd8359040c02b6614421c8e10cd7a788c40047dbc507ed46c29ae5636",
-                "sha256:94b564e38b344d3e67d2e224f0aec6ba09a77e4582ced41e7bfd0f757d926ec9",
-                "sha256:955a2a765aa1bd81aafa69ffda179d4fe3e2a3ad462a736ae5b6f387f78bfeb8",
-                "sha256:9d087663b7e1feabea8c578d6887d59bb00388158e8bff3a76be11aa3f748ca2",
-                "sha256:9df21b8d9e5c136ea6cde1c50d2b1c29a2b5ff2b1d610165c23ff250e0704087",
-                "sha256:a8998bf9f8658bd3839cbc44ddbe982955641863da0c1efe5b00c1ab4f5c16b1",
-                "sha256:b2eae3423e538c10d93ae3e87788c6a84658c3ed6db62e6a61bb9495b0ad16bb",
-                "sha256:b661b49d0cb0ab311a189b31e25576b7ac3e20783beb1e1817d72d9d02508bf5",
-                "sha256:bedee60385c1c0411378cbd4dc486362f5ee88deceea50002772912d798bb00f",
-                "sha256:c505edd429abdfe3643fa3b2e83efb3445a34a9dc49d5f692dd087be966020e0",
-                "sha256:cce918ada64c956b62ca2c2af59b125767097ec1dca89650a6221e887521bfd7",
-                "sha256:cf5ae8a9dcf657fd72144a7fd01f243236ea39e7344e579a121c4205aedf07bb",
-                "sha256:cf95a60b36997dad99692314c4713f141b61c5b0b4cc5c3426faad570b31ca01",
-                "sha256:d57bafbab289e147d064ffbd5cca2d7b1394b63417c0636cea1f2e93d16eb9e8",
-                "sha256:d70f53a0646cc418ca4853da57cf3ddddbccb8c98406791f24426f2dd77fd0e2",
-                "sha256:d75ead7dd4d255068ea0f21492ee67937bd7c90964c8f3c2bea83c7b7f81b95f",
-                "sha256:da36c3b0e891808a7542c5c89f224520b9a16c7f5e4d6a1156955605e54aef0e",
-                "sha256:db18ff6b8c0f1917f8b20f8eca35c28bbccb9f83afa94743e03d40203ed83de9",
-                "sha256:dfff7be361048244c3aa0f60b5e63221c5e0f0e509f4e47b8910e22b57d10ae7",
-                "sha256:e4fb5ac86d8fe8151966814f6720996430462e633d225497566b3996966b9bdb",
-                "sha256:e56a139bfe136a22c438478a86f8204c1eb5eed36f4e15c4224e4b9db01cb3e4",
-                "sha256:e6f5d254a22394847245f411a2956976401e84da4288aa70cbcd5190744062c1",
-                "sha256:e7402ff96e2b073a98ef6d6142796426d705addd27b9d26c3b32dbaa06d7d069",
-                "sha256:ea308cec940905ba008291d93619d92edaf83232ec85fbd514dcb329f3192761",
-                "sha256:eaa8039b6d20137a4e02603aba37d12cd2dde7887500b8855356682fc33933f4"
+                "sha256:0398361acebb42975deb747a824b5188817d32b5c8f8aba767d51ad0cc7bb08d",
+                "sha256:0561832b04c6071bac3aad45b0d3bb6d2c4f46a8409f0a7a9c9fa6673b41bc03",
+                "sha256:07258341402a718f166618470cde0c34e4cec85a39767dce4e24f61ba5e667ea",
+                "sha256:0a826f21848632add58bef4f755a33d45105d25656a0c849f2dc2df1c71f6f50",
+                "sha256:1052723e6cd95312f6a6eff9a279fd41bbae67633415373fdac3c430eca3425d",
+                "sha256:12d5b06a1f3aeccf295a5843c86835033797fea292c60e72b07bcb5d820e6dd3",
+                "sha256:12f5c9ed53334c3ce719155424dc5407aaa4f6cadeb09c5b627e06abb93933a1",
+                "sha256:2a0ef3f98175d77180ffdc623d38e9f1736e8d86b6ba70bff182a7e68bed7727",
+                "sha256:2f2951dc4b4f990a4b394d6b382accb33141d4d3bd3ef4e2b27287135d6bdd68",
+                "sha256:3868acb639c136d98107c9096303d2d8e5da2880f7706f9f8c06a7f961961149",
+                "sha256:386b7d136919bb66ced64d2228b92d66140de5fefb3c7df6bd79069a269a7b06",
+                "sha256:3d3043375dd5bbcb2282894cbb12e6c559654c67b5fffb462fda815a55bf93f7",
+                "sha256:3e35d5565b35b66905b79ca4ae85840a8d40d31e0b3e2990f2e7692071b179ca",
+                "sha256:402c2316d95ed90d3d3c25ad0390afa52f4d2c56b348f212aa9c8d072a40eee5",
+                "sha256:40310db77a55512a18827488e592965d3dec6a3f1e3d8af3f8243134029daca3",
+                "sha256:40e9cdbd18c1f84631312b64993f7d755d85a3930252f6276a77432a2b25a2f3",
+                "sha256:49aa2cdd1e88adb1617c672a09bf4ebf2f05c9448c6dbeba096a3aeeb9d4d443",
+                "sha256:57dd41ba32430cbcc812041d4de8d2ca4651aeefad2626921ae2a23deb8cd6ff",
+                "sha256:5dba1cdb8f319084f5b00d41207b2079822aa8d6a4667c0f369fce85e34b0c86",
+                "sha256:5e1d9e429028ce04f187a9f522818386c8b076723cdbe9345708384f49ebcec6",
+                "sha256:63178c675d4c80def39f1febd625a6333f44c0ba269edd8a468b156394b27753",
+                "sha256:6493bc0eacdbb2c0f0d260d8988e943fee06089cd239bd7f3d0c45d1657a70e2",
+                "sha256:64aa8934200e222f72fcfd82ee71c0130a9c07d5725af6fe6e919017d095b297",
+                "sha256:665255e7aae5f38237b3a6eae49d2358d83a59f39ac21036413fab5d1e810578",
+                "sha256:6db316d6e340f862ec059dc12e395d71f39746a20503b124edc255973977b728",
+                "sha256:70065dfabf023b155a9c2a18f573e47e6ca709b9e8619b2e04c54d5bcf193178",
+                "sha256:8455aa60da49cb112df62b4721bd8ad3654a3a02b9452c783e651637a1f21fa2",
+                "sha256:8b0ac78898c50e2574e9f938d2e5caa8fe187d7a5b69b65faa1ea4648925b096",
+                "sha256:8bf312ed8ac096d674c6aa9131b249093c1b37c35db6a967daa4c84746bc1bc9",
+                "sha256:92f99f2623ff16bd4aaf786ccde759c1f676d39c7bf2855eb0b540e1ac4530c8",
+                "sha256:9c8bcad7fc12f0cc5896d8e10fdf703c45bd487294a986903fe032c72201596b",
+                "sha256:9cd136184dd5f58892f24001cdce986f5d7e96059d004118d5410671579834a4",
+                "sha256:9eb4fa13c8c7a2404b6a8e3772c17a55b1ba18bc711e25e4d6c0c9f5f541b02a",
+                "sha256:a2bc4e49e8329f3283d99840c136ff2cd1a29e49b5624a46a290f04dff48e079",
+                "sha256:a5645cd45f56895cfe3ca3459aed9ff2d3f9aaa29ff7edf557fa7a23515a3725",
+                "sha256:a9afbc3909d0274d6ac8ec891e30210563b2c8bdd52ebbda14146354e7a69373",
+                "sha256:aa498d1392216fae47eaf10c593e06c34476ced9549657fca713d0d1ba5f7248",
+                "sha256:afd776cf1ebfc7f9aa42a09cf19feadb40a26366802d86c1fba080d8e5e74bdd",
+                "sha256:b335a7c958bc945e10c522c069cd6e5804f4ff20f9a744dd38e748eb602cbbda",
+                "sha256:b3c4817dff8cef5697f5afe5fec6bc1783994d55a68391be24cb7d80d2dbc3a6",
+                "sha256:b79ee64d01d05a5476d5cceb3c27b5535e6bb84ee0f872ba60d9a8cd4d0e6579",
+                "sha256:b87a90f14c68c925817423b0424381f0e16d80fc9a1a1046ef202ab25b19a444",
+                "sha256:bf89e0e4a30714b357f5d46b6f20e0099d38b30d45fa68ea48589faf5f12f62d",
+                "sha256:c058b84c3b24812c859300f3b5abf300daa34df20d4d4f42e9652a4d1c48c8a4",
+                "sha256:c09a6ea87658695e527104cf857c70f79f14e9484605e205217aae0ec27b45fc",
+                "sha256:c57b8e0841f3fce7b703530ed70c7c36269c6d180ea2e02e36b34cb7288c50c7",
+                "sha256:c9cea5b756173bb86e2235f2f871b406a9b9d722417ae31e5391ccaef5348f2c",
+                "sha256:cb39ed598aaf102251483f3e4675c5dd6b289c8142210ef76ba24aae0a8f8aba",
+                "sha256:e036549ad14f2b414c725349cce0772ea34a7ab008e9cd67f9084e4f371d1f32",
+                "sha256:e185ea07a99ce8b8edfc788c586c538c4b1351007e614ceb708fd01b095ef33e",
+                "sha256:e5a4d82bdb4bf1ac1285a68eab02d253ab73355d9f0fe725a97e1e0fa689decb",
+                "sha256:eae27ad7580529a427cfdd52c87abb2dfb15ce2b7a3e0fc29fbb63e2ed6f8120",
+                "sha256:ecef029b69843b82048c5b347d8e6049356aa24ed644006c9a9d7098c3bd3bfd",
+                "sha256:ee3bee874cb1fadee2ff2b79fc9fc808aa638670f28b2145074538d4a6a5028e",
+                "sha256:f0d3de936b192980209d7b5149e3c98977c3810d401482d05fb6d668d53c1c63",
+                "sha256:f53c0d6a859b2db58332e0e6a921582a02c1677cc93d4cbb36fdf49709b327b2",
+                "sha256:f9d57f1b3061b3e21476b0ad5f0397b112b94ace21d1f439f2db472e568178ae"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.37"
+            "version": "==2.0.38"
         },
         "sqlalchemy-continuum": {
             "hashes": [
@@ -3308,11 +3308,11 @@
         },
         "types-beautifulsoup4": {
             "hashes": [
-                "sha256:158370d08d0cd448bd11b132a50ff5279237a5d4b5837beba074de152a513059",
-                "sha256:c95e66ce15a4f5f0835f7fbc5cd886321ae8294f977c495424eaf4225307fd30"
+                "sha256:57ce9e75717b63c390fd789c787d267a67eb01fa6d800a03b9bdde2e877ed1eb",
+                "sha256:f083d8edcbd01279f8c3995b56cfff2d01f1bb894c3b502ba118d36fbbc495bf"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.12.0.20241020"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.12.0.20250204"
         },
         "types-bleach": {
             "hashes": [
@@ -3402,11 +3402,11 @@
         },
         "ua-parser": {
             "hashes": [
-                "sha256:5b31133606a781f56692caa11a9671a9f330c22604b3c4957a7ba18c152212d0",
-                "sha256:a9740f53f4fbb72b7a03d304cae32a2785cafc55e8207efb74877bba17c35324"
+                "sha256:b059f2cb0935addea7e551251cbbf42e9a8872f86134163bc1a4f79e0945ffea",
+                "sha256:f9d92bf19d4329019cef91707aecc23c6d65143ad7e29a233f0580fb0d15547d"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.0.0"
+            "version": "==1.0.1"
         },
         "ua-parser-builtins": {
             "hashes": [
@@ -3702,47 +3702,47 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff",
-                "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"
+                "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e",
+                "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.3.0"
+            "version": "==25.1.0"
         },
         "babel": {
             "hashes": [
-                "sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b",
-                "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"
+                "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d",
+                "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.16.0"
+            "version": "==2.17.0"
         },
         "black": {
             "hashes": [
-                "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f",
-                "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd",
-                "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea",
-                "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981",
-                "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b",
-                "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7",
-                "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8",
-                "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175",
-                "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d",
-                "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392",
-                "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad",
-                "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f",
-                "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f",
-                "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b",
-                "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875",
-                "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3",
-                "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800",
-                "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65",
-                "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2",
-                "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812",
-                "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50",
-                "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"
+                "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171",
+                "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7",
+                "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da",
+                "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2",
+                "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc",
+                "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666",
+                "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f",
+                "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b",
+                "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32",
+                "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f",
+                "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717",
+                "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299",
+                "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0",
+                "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18",
+                "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0",
+                "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3",
+                "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355",
+                "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096",
+                "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e",
+                "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9",
+                "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba",
+                "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==24.10.0"
+            "version": "==25.1.0"
         },
         "build": {
             "hashes": [
@@ -3754,11 +3754,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
-                "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"
+                "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651",
+                "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.12.14"
+            "version": "==2025.1.31"
         },
         "charset-normalizer": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0cf55d3ee4c2c569fc7867a1dda53fd7e8aec466c5b264aab87d0249c40777b4"
+            "sha256": "37752494d8fd62d499261123a80a0c2d33ddb54b0daf6ae6fe61bd5e7c9e89b4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -428,43 +428,48 @@
         },
         "counter-robots": {
             "hashes": [
-                "sha256:6c231604a4bfa9b93d47d484e7e38219f231bdd15436561b0f4a2afc8a9f5b42",
-                "sha256:b4f4c4a0ce854fd4f012934084f8d5060ef9b2008e4e90d96cc79265dc93e7a9"
+                "sha256:c34d8a3a1df728775f48196f74242c37268b9abc7d919cf4f2a5b6ac879514b7",
+                "sha256:dc477abd4199b64211b25f42307ee0835598aa9fbe732a889717466780d3d3f3"
             ],
-            "version": "==2018.6"
+            "markers": "python_version >= '3.7'",
+            "version": "==2025.2"
         },
         "cryptography": {
             "hashes": [
-                "sha256:1923cb251c04be85eec9fda837661c67c1049063305d6be5721643c22dd4e2b7",
-                "sha256:37d76e6863da3774cd9db5b409a9ecfd2c71c981c38788d3fcfaf177f447b731",
-                "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b",
-                "sha256:404fdc66ee5f83a1388be54300ae978b2efd538018de18556dde92575e05defc",
-                "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543",
-                "sha256:62901fb618f74d7d81bf408c8719e9ec14d863086efe4185afd07c352aee1d2c",
-                "sha256:660cb7312a08bc38be15b696462fa7cc7cd85c3ed9c576e81f4dc4d8b2b31591",
-                "sha256:708ee5f1bafe76d041b53a4f95eb28cdeb8d18da17e597d46d7833ee59b97ede",
-                "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb",
-                "sha256:831c3c4d0774e488fdc83a1923b49b9957d33287de923d58ebd3cec47a0ae43f",
-                "sha256:84111ad4ff3f6253820e6d3e58be2cc2a00adb29335d4cacb5ab4d4d34f2a123",
-                "sha256:8b3e6eae66cf54701ee7d9c83c30ac0a1e3fa17be486033000f2a73a12ab507c",
-                "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c",
-                "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285",
-                "sha256:abc998e0c0eee3c8a1904221d3f67dcfa76422b23620173e28c11d3e626c21bd",
-                "sha256:b15492a11f9e1b62ba9d73c210e2416724633167de94607ec6069ef724fad092",
-                "sha256:be4ce505894d15d5c5037167ffb7f0ae90b7be6f2a98f9a5c3442395501c32fa",
-                "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289",
-                "sha256:cd4e834f340b4293430701e772ec543b0fbe6c2dea510a5286fe0acabe153a02",
-                "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64",
-                "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053",
-                "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417",
-                "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e",
-                "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e",
-                "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7",
-                "sha256:f5e7cb1e5e56ca0933b4873c0220a78b773b24d40d186b6738080b73d3d0a756",
-                "sha256:f677e1268c4e23420c3acade68fac427fffcb8d19d7df95ed7ad17cdef8404f4"
+                "sha256:00918d859aa4e57db8299607086f793fa7813ae2ff5a4637e318a25ef82730f7",
+                "sha256:1e8d181e90a777b63f3f0caa836844a1182f1f265687fac2115fcf245f5fbec3",
+                "sha256:1f9a92144fa0c877117e9748c74501bea842f93d21ee00b0cf922846d9d0b183",
+                "sha256:21377472ca4ada2906bc313168c9dc7b1d7ca417b63c1c3011d0c74b7de9ae69",
+                "sha256:24979e9f2040c953a94bf3c6782e67795a4c260734e5264dceea65c8f4bae64a",
+                "sha256:2a46a89ad3e6176223b632056f321bc7de36b9f9b93b2cc1cccf935a3849dc62",
+                "sha256:322eb03ecc62784536bc173f1483e76747aafeb69c8728df48537eb431cd1911",
+                "sha256:436df4f203482f41aad60ed1813811ac4ab102765ecae7a2bbb1dbb66dcff5a7",
+                "sha256:4f422e8c6a28cf8b7f883eb790695d6d45b0c385a2583073f3cec434cc705e1a",
+                "sha256:53f23339864b617a3dfc2b0ac8d5c432625c80014c25caac9082314e9de56f41",
+                "sha256:5fed5cd6102bb4eb843e3315d2bf25fede494509bddadb81e03a859c1bc17b83",
+                "sha256:610a83540765a8d8ce0f351ce42e26e53e1f774a6efb71eb1b41eb01d01c3d12",
+                "sha256:6c8acf6f3d1f47acb2248ec3ea261171a671f3d9428e34ad0357148d492c7864",
+                "sha256:6f76fdd6fd048576a04c5210d53aa04ca34d2ed63336d4abd306d0cbe298fddf",
+                "sha256:72198e2b5925155497a5a3e8c216c7fb3e64c16ccee11f0e7da272fa93b35c4c",
+                "sha256:887143b9ff6bad2b7570da75a7fe8bbf5f65276365ac259a5d2d5147a73775f2",
+                "sha256:888fcc3fce0c888785a4876ca55f9f43787f4c5c1cc1e2e0da71ad481ff82c5b",
+                "sha256:8e6a85a93d0642bd774460a86513c5d9d80b5c002ca9693e63f6e540f1815ed0",
+                "sha256:94f99f2b943b354a5b6307d7e8d19f5c423a794462bde2bf310c770ba052b1c4",
+                "sha256:9b336599e2cb77b1008cb2ac264b290803ec5e8e89d618a5e978ff5eb6f715d9",
+                "sha256:a2d8a7045e1ab9b9f803f0d9531ead85f90c5f2859e653b61497228b18452008",
+                "sha256:b8272f257cf1cbd3f2e120f14c68bff2b6bdfcc157fafdee84a1b795efd72862",
+                "sha256:bf688f615c29bfe9dfc44312ca470989279f0e94bb9f631f85e3459af8efc009",
+                "sha256:d9c5b9f698a83c8bd71e0f4d3f9f839ef244798e5ffe96febfa9714717db7af7",
+                "sha256:dd7c7e2d71d908dc0f8d2027e1604102140d84b155e658c20e8ad1304317691f",
+                "sha256:df978682c1504fc93b3209de21aeabf2375cb1571d4e61907b3e7a2540e83026",
+                "sha256:e403f7f766ded778ecdb790da786b418a9f2394f36e8cc8b796cc056ab05f44f",
+                "sha256:eb3889330f2a4a148abead555399ec9a32b13b7c8ba969b72d8e500eb7ef84cd",
+                "sha256:f4daefc971c2d1f82f03097dc6f216744a6cd2ac0f04c68fb935ea2ba2a0d420",
+                "sha256:f51f5705ab27898afda1aaa430f34ad90dc117421057782022edf0600bec5f14",
+                "sha256:fd0ee90072861e276b0ff08bd627abec29e32a53b2be44e41dbcdf87cbee2b00"
             ],
             "markers": "python_version >= '3.7' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==44.0.0"
+            "version": "==44.0.1"
         },
         "cssselect2": {
             "hashes": [
@@ -590,11 +595,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:28c24061780f83b45d9cb15a72b8f143b09d276c9ff52eb557744b7a89e8ba19",
-                "sha256:609abe555761ff31b0e5e16f958696e9b65c9224a7ac612ac96bfc2b8f09fe35"
+                "sha256:aa0b93487d3adf7cd89953d172e3df896cb7b35d8a5222c0da873edbe2f7adf5",
+                "sha256:f40510350aecfe006f45cb3f8879b35e861367cf347f51a7f2ca2c0571fdcc0b"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==35.2.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==36.1.0"
         },
         "fastjsonschema": {
             "hashes": [
@@ -1014,11 +1019,11 @@
                 "opensearch2"
             ],
             "hashes": [
-                "sha256:08e2d8090ff373d682f7b42f3fff506287204ee1c71b7771e80cfe8c9bc8e5e2",
-                "sha256:6cdbc658fcaf824072b9a43e2ff0564bdae6bbe8e5eb8eb2d806845ecca9f59a"
+                "sha256:ceaaa1c17bb726e8d1ef6762cd519efa6fa444aed208820ef266740a41ef5df2",
+                "sha256:d68c13bdb80ed0c0ff2edf79a804324d21a0cf45e2a6663471fdb18cf7a8cb6a"
             ],
             "index": "pypi",
-            "version": "==13.0.0b2.dev1"
+            "version": "==13.0.0b2.dev2"
         },
         "invenio-assets": {
             "hashes": [
@@ -1062,11 +1067,11 @@
         },
         "invenio-communities": {
             "hashes": [
-                "sha256:b751098c29502efc2aa988e420518f2bc7cdc328c4544bf4c523dea91e7629dd",
-                "sha256:d75ea42813945a992cfde14cae075eb2ee6e372047b063c3ef4a407ee08f3e10"
+                "sha256:711c7a382df305b17462e943b34193c134db46295990b54e99268e85bfc68939",
+                "sha256:fbe68ee8da80bba6acb296aab510f113e2efe543ac557e8fd2dd7cb308f17501"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==18.0.0.dev2"
+            "version": "==18.0.0"
         },
         "invenio-config": {
             "hashes": [
@@ -1134,11 +1139,11 @@
         },
         "invenio-jobs": {
             "hashes": [
-                "sha256:07f6557addd3f02755e94c1545f68232cb24bc1ce6e7b1cde1f68cae6e9edac3",
-                "sha256:ad00c919dcedab3b043981b5c99cbd0df6bb2fd27138f17868159562df2a2b16"
+                "sha256:4549a7c2018590d5832f4c61c49b462175a7edf5e06eaef4e19234a1257a45d2",
+                "sha256:da3170d393009fcf5d7800c2ed3d7c3e8298fd5bee5ef5a744a4f538aebb6147"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.0.0.dev2"
+            "version": "==3.0.0"
         },
         "invenio-jsonschemas": {
             "hashes": [
@@ -1230,11 +1235,11 @@
         },
         "invenio-rdm-records": {
             "hashes": [
-                "sha256:6433bf17ee5fa03a7ccb1e64e28689b08c0012da3bc16c2f506f8a034ccb607c",
-                "sha256:d5adf5c4a200c944be5c31ab2fe187c77e17ce4556a1ca8b84ec095e83f7e2bc"
+                "sha256:36f623c8af2ca0f2ae9f760b433c4842b7af33d09732ea126092b1df12d743dd",
+                "sha256:5d46a7b56edc48f8e87af7dda38e4b7fd2b61bb3791978ac0dde63056c8beee9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==17.0.0.dev2"
+            "version": "==17.0.1"
         },
         "invenio-records": {
             "hashes": [
@@ -1285,11 +1290,11 @@
         },
         "invenio-requests": {
             "hashes": [
-                "sha256:190f1c9baf836e2a7ceb6bfc51bad4c24a0cd7cc462abcad2043358bd6089505",
-                "sha256:43c4194daaa855003eb440f30cd98d844d8d4df2d660132a7cae2118db261ff9"
+                "sha256:199fb2045b9007fa9812bdad4cf7e2e8d1f5d960f918bdcdbbf1502ee9aa753c",
+                "sha256:31a1150be748faf194e9374ae2c2f0b5e23efa467c324d0f38f1cf1026d977f9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.0.0.dev2"
+            "version": "==6.0.0"
         },
         "invenio-rest": {
             "hashes": [
@@ -1327,7 +1332,7 @@
         },
         "invenio-swh": {
             "git": "https://github.com/inveniosoftware/invenio-swh",
-            "ref": "81ed234bf47c85e8babf04ae85ebae145929329f"
+            "ref": "334013c6f4b227fdf6f8d304fa563331aec4c3fd"
         },
         "invenio-theme": {
             "hashes": [
@@ -1347,19 +1352,19 @@
         },
         "invenio-users-resources": {
             "hashes": [
-                "sha256:10a0d0ddcd1e318f150355d6f434f0c7cc0860b127a6e3f362956339894cc54d",
-                "sha256:98a97201c4272cf113af29a96d8985ddc18f40037278b03a985b658e19ca68cf"
+                "sha256:501d464d5a0acd2987cb921db16177ba155f367a2df745730574a6abf421a359",
+                "sha256:5e70e7fd733034fb634a5aab56dc3686f8c559b4a8000feb18656107038eb435"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.0.0.dev2"
+            "version": "==7.0.0"
         },
         "invenio-vocabularies": {
             "hashes": [
-                "sha256:7164c4ccf2eed4cfed98432b05d1fab2a69b8b8a17c06f925e4d19e0400f2839",
-                "sha256:79b495ccafa790e0121ad0bf3f2af83ad64222d15aa0591d23573c4a901e9c77"
+                "sha256:1427b3d90e369d868d852c66a5d475cc1647c508a0a4a7ecede92268d3dcf332",
+                "sha256:186edcae6512354129e0b24b5b8efc0d27b63727effff6a16798b47debfbf4ca"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.0.0.dev2"
+            "version": "==7.0.0"
         },
         "invenio-webhooks": {
             "hashes": [
@@ -1448,11 +1453,11 @@
         },
         "jsonresolver": {
             "hashes": [
-                "sha256:33ed39dc582db4b011a1356ebb76c43317f069f01f98f357da9a4cdb6a6539d5",
-                "sha256:66d70fd43d0b961a18aa09917bd1a49400f0adb7ed70fb2611188f319f306ed9"
+                "sha256:737e0eaea942b95bbd7f8f9e0c61965293f0a26c536d7efddf7f07410f96a749",
+                "sha256:c06e415a45ed55ed661a7e70df0ba32eefc06b5f25e48a0b9085f495f5d6d490"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.3.2"
+            "version": "==0.4.0"
         },
         "jsonschema": {
             "hashes": [
@@ -2149,11 +2154,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.13.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
         },
         "ply": {
             "hashes": [
@@ -3324,11 +3329,11 @@
         },
         "types-dateparser": {
             "hashes": [
-                "sha256:8f813ddf5ef41b32cabe6167138ae833ada10c22811e42220a1e38a0be7adbdc",
-                "sha256:bf3695ddfbadfdfc875064895a51d926fd80b04da1a44364c6c1a9703db7b194"
+                "sha256:11ad024b43a655bcab564f21b172a117e6a09d0fc2e8a8131f52e5b68a59a2a6",
+                "sha256:bfe9d2f36fca22900797bfdd240e3175d885b9541237447ddd7161ea1be2ff77"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.2.0.20240420"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.2.0.20250208"
         },
         "types-html5lib": {
             "hashes": [
@@ -3394,11 +3399,11 @@
         },
         "tzlocal": {
             "hashes": [
-                "sha256:49816ef2fe65ea8ac19d19aa7a1ae0551c834303d5014c6d5a62e4cbda8047b8",
-                "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e"
+                "sha256:2fafbfc07e9d8b49ade18f898d6bcd37ae88ce3ad6486842a2e4f03af68323d2",
+                "sha256:3814135a1bb29763c6e4f08fd6e41dbb435c7a60bfbb03270211bcc537187d8c"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==5.3"
         },
         "ua-parser": {
             "hashes": [
@@ -3744,6 +3749,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==25.1.0"
         },
+        "blinker": {
+            "hashes": [
+                "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf",
+                "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.9.0"
+        },
         "build": {
             "hashes": [
                 "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5",
@@ -3876,71 +3889,72 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:05fca8ba6a87aabdd2d30d0b6c838b50510b56cdcfc604d40760dae7153b73d9",
-                "sha256:0aa9692b4fdd83a4647eeb7db46410ea1322b5ed94cd1715ef09d1d5922ba87f",
-                "sha256:0c807ca74d5a5e64427c8805de15b9ca140bba13572d6d74e262f46f50b13273",
-                "sha256:0d7a2bf79378d8fb8afaa994f91bfd8215134f8631d27eba3e0e2c13546ce994",
-                "sha256:0f460286cb94036455e703c66988851d970fdfd8acc2a1122ab7f4f904e4029e",
-                "sha256:204a8238afe787323a8b47d8be4df89772d5c1e4651b9ffa808552bdf20e1d50",
-                "sha256:2396e8116db77789f819d2bc8a7e200232b7a282c66e0ae2d2cd84581a89757e",
-                "sha256:254f1a3b1eef5f7ed23ef265eaa89c65c8c5b6b257327c149db1ca9d4a35f25e",
-                "sha256:26bcf5c4df41cad1b19c84af71c22cbc9ea9a547fc973f1f2cc9a290002c8b3c",
-                "sha256:27c6e64726b307782fa5cbe531e7647aee385a29b2107cd87ba7c0105a5d3853",
-                "sha256:299e91b274c5c9cdb64cbdf1b3e4a8fe538a7a86acdd08fae52301b28ba297f8",
-                "sha256:2bcfa46d7709b5a7ffe089075799b902020b62e7ee56ebaed2f4bdac04c508d8",
-                "sha256:2ccf240eb719789cedbb9fd1338055de2761088202a9a0b73032857e53f612fe",
-                "sha256:32ee6d8491fcfc82652a37109f69dee9a830e9379166cb73c16d8dc5c2915165",
-                "sha256:3f7b444c42bbc533aaae6b5a2166fd1a797cdb5eb58ee51a92bee1eb94a1e1cb",
-                "sha256:457574f4599d2b00f7f637a0700a6422243b3565509457b2dbd3f50703e11f59",
-                "sha256:489a01f94aa581dbd961f306e37d75d4ba16104bbfa2b0edb21d29b73be83609",
-                "sha256:4bcc276261505d82f0ad426870c3b12cb177752834a633e737ec5ee79bbdff18",
-                "sha256:4e0de1e902669dccbf80b0415fb6b43d27edca2fbd48c74da378923b05316098",
-                "sha256:4e4630c26b6084c9b3cb53b15bd488f30ceb50b73c35c5ad7871b869cb7365fd",
-                "sha256:4eea95ef275de7abaef630c9b2c002ffbc01918b726a39f5a4353916ec72d2f3",
-                "sha256:507a20fc863cae1d5720797761b42d2d87a04b3e5aeb682ef3b7332e90598f43",
-                "sha256:54a5f0f43950a36312155dae55c505a76cd7f2b12d26abeebbe7a0b36dbc868d",
-                "sha256:55b201b97286cf61f5e76063f9e2a1d8d2972fc2fcfd2c1272530172fd28c359",
-                "sha256:59af35558ba08b758aec4d56182b222976330ef8d2feacbb93964f576a7e7a90",
-                "sha256:5c912978f7fbf47ef99cec50c4401340436d200d41d714c7a4766f377c5b7b78",
-                "sha256:656c82b8a0ead8bba147de9a89bda95064874c91a3ed43a00e687f23cc19d53a",
-                "sha256:6713ba4b4ebc330f3def51df1d5d38fad60b66720948112f114968feb52d3f99",
-                "sha256:675cefc4c06e3b4c876b85bfb7c59c5e2218167bbd4da5075cbe3b5790a28988",
-                "sha256:6f93531882a5f68c28090f901b1d135de61b56331bba82028489bc51bdd818d2",
-                "sha256:714f942b9c15c3a7a5fe6876ce30af831c2ad4ce902410b7466b662358c852c0",
-                "sha256:79109c70cc0882e4d2d002fe69a24aa504dec0cc17169b3c7f41a1d341a73694",
-                "sha256:7bbd8c8f1b115b892e34ba66a097b915d3871db7ce0e6b9901f462ff3a975377",
-                "sha256:7ed2f37cfce1ce101e6dffdfd1c99e729dd2ffc291d02d3e2d0af8b53d13840d",
-                "sha256:7fb105327c8f8f0682e29843e2ff96af9dcbe5bab8eeb4b398c6a33a16d80a23",
-                "sha256:89d76815a26197c858f53c7f6a656686ec392b25991f9e409bcef020cd532312",
-                "sha256:9a7cfb50515f87f7ed30bc882f68812fd98bc2852957df69f3003d22a2aa0abf",
-                "sha256:9e1747bab246d6ff2c4f28b4d186b205adced9f7bd9dc362051cc37c4a0c7bd6",
-                "sha256:9e80eba8801c386f72e0712a0453431259c45c3249f0009aff537a517b52942b",
-                "sha256:a01ec4af7dfeb96ff0078ad9a48810bb0cc8abcb0115180c6013a6b26237626c",
-                "sha256:a372c89c939d57abe09e08c0578c1d212e7a678135d53aa16eec4430adc5e690",
-                "sha256:a3b204c11e2b2d883946fe1d97f89403aa1811df28ce0447439178cc7463448a",
-                "sha256:a534738b47b0de1995f85f582d983d94031dffb48ab86c95bdf88dc62212142f",
-                "sha256:a5e37dc41d57ceba70956fa2fc5b63c26dba863c946ace9705f8eca99daecdc4",
-                "sha256:aa744da1820678b475e4ba3dfd994c321c5b13381d1041fe9c608620e6676e25",
-                "sha256:ab32947f481f7e8c763fa2c92fd9f44eeb143e7610c4ca9ecd6a36adab4081bd",
-                "sha256:abb02e2f5a3187b2ac4cd46b8ced85a0858230b577ccb2c62c81482ca7d18852",
-                "sha256:b330368cb99ef72fcd2dc3ed260adf67b31499584dc8a20225e85bfe6f6cfed0",
-                "sha256:bc67deb76bc3717f22e765ab3e07ee9c7a5e26b9019ca19a3b063d9f4b874244",
-                "sha256:c0b1818063dc9e9d838c09e3a473c1422f517889436dd980f5d721899e66f315",
-                "sha256:c56e097019e72c373bae32d946ecf9858fda841e48d82df7e81c63ac25554078",
-                "sha256:c7827a5bc7bdb197b9e066cdf650b2887597ad124dd99777332776f7b7c7d0d0",
-                "sha256:ccc2b70a7ed475c68ceb548bf69cec1e27305c1c2606a5eb7c3afff56a1b3b27",
-                "sha256:d37a84878285b903c0fe21ac8794c6dab58150e9359f1aaebbeddd6412d53132",
-                "sha256:e2f0280519e42b0a17550072861e0bc8a80a0870de260f9796157d3fca2733c5",
-                "sha256:e4ae5ac5e0d1e4edfc9b4b57b4cbecd5bc266a6915c500f358817a8496739247",
-                "sha256:e67926f51821b8e9deb6426ff3164870976fe414d033ad90ea75e7ed0c2e5022",
-                "sha256:e78b270eadb5702938c3dbe9367f878249b5ef9a2fcc5360ac7bff694310d17b",
-                "sha256:ea3c8f04b3e4af80e17bab607c386a830ffc2fb88a5484e1df756478cf70d1d3",
-                "sha256:ec22b5e7fe7a0fa8509181c4aac1db48f3dd4d3a566131b313d1efc102892c18",
-                "sha256:f4f620668dbc6f5e909a0946a877310fb3d57aea8198bde792aae369ee1c23b5",
-                "sha256:fd34e7b3405f0cc7ab03d54a334c17a9e802897580d964bd8c2001f4b9fd488f"
+                "sha256:00b2086892cf06c7c2d74983c9595dc511acca00665480b3ddff749ec4fb2a95",
+                "sha256:0533adc29adf6a69c1baa88c3d7dbcaadcffa21afbed3ca7a225a440e4744bf9",
+                "sha256:06097c7abfa611c91edb9e6920264e5be1d6ceb374efb4986f38b09eed4cb2fe",
+                "sha256:07e92ae5a289a4bc4c0aae710c0948d3c7892e20fd3588224ebe242039573bf0",
+                "sha256:0a9d8be07fb0832636a0f72b80d2a652fe665e80e720301fb22b191c3434d924",
+                "sha256:0e549f54ac5f301e8e04c569dfdb907f7be71b06b88b5063ce9d6953d2d58574",
+                "sha256:0ef01d70198431719af0b1f5dcbefc557d44a190e749004042927b2a3fed0702",
+                "sha256:0f16f44025c06792e0fb09571ae454bcc7a3ec75eeb3c36b025eccf501b1a4c3",
+                "sha256:14d47376a4f445e9743f6c83291e60adb1b127607a3618e3185bbc8091f0467b",
+                "sha256:1a936309a65cc5ca80fa9f20a442ff9e2d06927ec9a4f54bcba9c14c066323f2",
+                "sha256:1ceeb90c3eda1f2d8c4c578c14167dbd8c674ecd7d38e45647543f19839dd6ea",
+                "sha256:1f7ffa05da41754e20512202c866d0ebfc440bba3b0ed15133070e20bf5aeb5f",
+                "sha256:200e10beb6ddd7c3ded322a4186313d5ca9e63e33d8fab4faa67ef46d3460af3",
+                "sha256:220fa6c0ad7d9caef57f2c8771918324563ef0d8272c94974717c3909664e674",
+                "sha256:2251fabcfee0a55a8578a9d29cecfee5f2de02f11530e7d5c5a05859aa85aee9",
+                "sha256:2458f275944db8129f95d91aee32c828a408481ecde3b30af31d552c2ce284a0",
+                "sha256:299cf973a7abff87a30609879c10df0b3bfc33d021e1adabc29138a48888841e",
+                "sha256:2b996819ced9f7dbb812c701485d58f261bef08f9b85304d41219b1496b591ef",
+                "sha256:3688b99604a24492bcfe1c106278c45586eb819bf66a654d8a9a1433022fb2eb",
+                "sha256:3a1e465f398c713f1b212400b4e79a09829cd42aebd360362cd89c5bdc44eb87",
+                "sha256:488c27b3db0ebee97a830e6b5a3ea930c4a6e2c07f27a5e67e1b3532e76b9ef1",
+                "sha256:48cfc4641d95d34766ad41d9573cc0f22a48aa88d22657a1fe01dca0dbae4de2",
+                "sha256:4b467a8c56974bf06e543e69ad803c6865249d7a5ccf6980457ed2bc50312703",
+                "sha256:53c56358d470fa507a2b6e67a68fd002364d23c83741dbc4c2e0680d80ca227e",
+                "sha256:5d1095bbee1851269f79fd8e0c9b5544e4c00c0c24965e66d8cba2eb5bb535fd",
+                "sha256:641dfe0ab73deb7069fb972d4d9725bf11c239c309ce694dd50b1473c0f641c3",
+                "sha256:64cbb1a3027c79ca6310bf101014614f6e6e18c226474606cf725238cf5bc2d4",
+                "sha256:66fe626fd7aa5982cdebad23e49e78ef7dbb3e3c2a5960a2b53632f1f703ea45",
+                "sha256:676f92141e3c5492d2a1596d52287d0d963df21bf5e55c8b03075a60e1ddf8aa",
+                "sha256:69e62c5034291c845fc4df7f8155e8544178b6c774f97a99e2734b05eb5bed31",
+                "sha256:704c8c8c6ce6569286ae9622e534b4f5b9759b6f2cd643f1c1a61f666d534fe8",
+                "sha256:78f5243bb6b1060aed6213d5107744c19f9571ec76d54c99cc15938eb69e0e86",
+                "sha256:79cac3390bfa9836bb795be377395f28410811c9066bc4eefd8015258a7578c6",
+                "sha256:7ae6eabf519bc7871ce117fb18bf14e0e343eeb96c377667e3e5dd12095e0288",
+                "sha256:7e39e845c4d764208e7b8f6a21c541ade741e2c41afabdfa1caa28687a3c98cf",
+                "sha256:8161d9fbc7e9fe2326de89cd0abb9f3599bccc1287db0aba285cb68d204ce929",
+                "sha256:8bec2ac5da793c2685ce5319ca9bcf4eee683b8a1679051f8e6ec04c4f2fd7dc",
+                "sha256:959244a17184515f8c52dcb65fb662808767c0bd233c1d8a166e7cf74c9ea985",
+                "sha256:9b148068e881faa26d878ff63e79650e208e95cf1c22bd3f77c3ca7b1d9821a3",
+                "sha256:aa6f302a3a0b5f240ee201297fff0bbfe2fa0d415a94aeb257d8b461032389bd",
+                "sha256:ace9048de91293e467b44bce0f0381345078389814ff6e18dbac8fdbf896360e",
+                "sha256:ad7525bf0241e5502168ae9c643a2f6c219fa0a283001cee4cf23a9b7da75879",
+                "sha256:b01a840ecc25dce235ae4c1b6a0daefb2a203dba0e6e980637ee9c2f6ee0df57",
+                "sha256:b076e625396e787448d27a411aefff867db2bffac8ed04e8f7056b07024eed5a",
+                "sha256:b172f8e030e8ef247b3104902cc671e20df80163b60a203653150d2fc204d1ad",
+                "sha256:b1f097878d74fe51e1ddd1be62d8e3682748875b461232cf4b52ddc6e6db0bba",
+                "sha256:b95574d06aa9d2bd6e5cc35a5bbe35696342c96760b69dc4287dbd5abd4ad51d",
+                "sha256:bda1c5f347550c359f841d6614fb8ca42ae5cb0b74d39f8a1e204815ebe25750",
+                "sha256:cec6b9ce3bd2b7853d4a4563801292bfee40b030c05a3d29555fd2a8ee9bd68c",
+                "sha256:d1a987778b9c71da2fc8948e6f2656da6ef68f59298b7e9786849634c35d2c3c",
+                "sha256:d74c08e9aaef995f8c4ef6d202dbd219c318450fe2a76da624f2ebb9c8ec5d9f",
+                "sha256:e18aafdfb3e9ec0d261c942d35bd7c28d031c5855dadb491d2723ba54f4c3015",
+                "sha256:e216c5c45f89ef8971373fd1c5d8d1164b81f7f5f06bbf23c37e7908d19e8558",
+                "sha256:e695df2c58ce526eeab11a2e915448d3eb76f75dffe338ea613c1201b33bab2f",
+                "sha256:e7575ab65ca8399c8c4f9a7d61bbd2d204c8b8e447aab9d355682205c9dd948d",
+                "sha256:e995b3b76ccedc27fe4f477b349b7d64597e53a43fc2961db9d3fbace085d69d",
+                "sha256:ea31689f05043d520113e0552f039603c4dd71fa4c287b64cb3606140c66f425",
+                "sha256:eb5507795caabd9b2ae3f1adc95f67b1104971c22c624bb354232d65c4fc90b3",
+                "sha256:eb8668cfbc279a536c633137deeb9435d2962caec279c3f8cf8b91fff6ff8953",
+                "sha256:ecea0c38c9079570163d663c0433a9af4094a60aafdca491c6a3d248c7432827",
+                "sha256:f25d8b92a4e31ff1bd873654ec367ae811b3a943583e05432ea29264782dc32c",
+                "sha256:f60a297c3987c6c02ffb29effc70eadcbb412fe76947d394a1091a3615948e2f",
+                "sha256:f973643ef532d4f9be71dd88cf7588936685fdb576d93a79fe9f65bc337d9d73"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==7.6.10"
+            "version": "==7.6.12"
         },
         "docker-services-cli": {
             "hashes": [
@@ -3958,6 +3972,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==0.19"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
+                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.2"
+        },
         "flask": {
             "hashes": [
                 "sha256:5f873c5184c897c8d9d1b05df1e3d01b14910ce69607a117bd3277098a5836ac",
@@ -3965,6 +3987,14 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==3.1.0"
+        },
+        "h11": {
+            "hashes": [
+                "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
+                "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.14.0"
         },
         "idna": {
             "hashes": [
@@ -4008,11 +4038,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109",
-                "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
+                "sha256:567954102bb47bb12e0fae62606570faacddd441e45683968c8d1734fb1af892",
+                "sha256:75d9d8a1438a9432a7d7b54f2d3b45cad9a4a0fdba43617d9873379704a8bdf1"
             ],
             "index": "pypi",
-            "version": "==5.13.2"
+            "version": "==6.0.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -4105,6 +4135,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.0.0"
         },
+        "outcome": {
+            "hashes": [
+                "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8",
+                "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.0.post0"
+        },
         "packaging": {
             "hashes": [
                 "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
@@ -4131,11 +4169,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.13.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
         },
         "py": {
             "hashes": [
@@ -4177,13 +4215,21 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.2.0"
         },
+        "pysocks": {
+            "hashes": [
+                "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299",
+                "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5",
+                "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"
+            ],
+            "version": "==1.7.1"
+        },
         "pytest": {
             "hashes": [
-                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
-                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
+                "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6",
+                "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==7.1.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==8.3.4"
         },
         "pytest-black": {
             "hashes": [
@@ -4219,11 +4265,11 @@
         },
         "pytest-invenio": {
             "hashes": [
-                "sha256:8c40a370f8fb02087a4c1d031f2c23c54d8a1481be5e783532eb823c826a6ec2",
-                "sha256:b759a791c94fc79d811ad74acf795fa3b5b1293a0cd852527d537d7d40f9a180"
+                "sha256:8ffe0bedf4b5af95a1d6561b394eb74df5bdbe7818e30a2203e86e0e70e40b70",
+                "sha256:e4ab188c6780df0a740b6d88496f13e2fd51e02f475bd4c00d100f3866707a25"
             ],
             "index": "pypi",
-            "version": "==2.2.1"
+            "version": "==3.0.0"
         },
         "pytest-isort": {
             "hashes": [
@@ -4257,10 +4303,11 @@
         },
         "selenium": {
             "hashes": [
-                "sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c",
-                "sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d"
+                "sha256:0072d08670d7ec32db901bd0107695a330cecac9f196e3afb3fa8163026e022a",
+                "sha256:4238847e45e24e4472cfcf3554427512c7aab9443396435b1623ef406fff1cc1"
             ],
-            "version": "==3.141.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.28.1"
         },
         "setuptools": {
             "hashes": [
@@ -4270,12 +4317,27 @@
             "markers": "python_version >= '3.9'",
             "version": "==75.8.0"
         },
+        "sniffio": {
+            "hashes": [
+                "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2",
+                "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.1"
+        },
         "snowballstemmer": {
             "hashes": [
                 "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
                 "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
             ],
             "version": "==2.2.0"
+        },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
+                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            ],
+            "version": "==2.4.0"
         },
         "sphinx": {
             "hashes": [
@@ -4379,6 +4441,22 @@
             "markers": "python_version < '3.11'",
             "version": "==2.2.1"
         },
+        "trio": {
+            "hashes": [
+                "sha256:4e547896fe9e8a5658e54e4c7c5fa1db748cbbbaa7c965e7d40505b928c73c05",
+                "sha256:56d58977acc1635735a96581ec70513cc781b8b6decd299c487d3be2a721cd94"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.28.0"
+        },
+        "trio-websocket": {
+            "hashes": [
+                "sha256:18c11793647703c158b1f6e62de638acada927344d534e3c7628eedcb746839f",
+                "sha256:520d046b0d030cf970b8b2b2e00c4c2245b3807853ecd44214acd33d74581638"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.11.1"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
@@ -4395,6 +4473,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==1.26.20"
         },
+        "websocket-client": {
+            "hashes": [
+                "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526",
+                "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.8.0"
+        },
         "werkzeug": {
             "hashes": [
                 "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e",
@@ -4402,6 +4488,14 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==3.1.3"
+        },
+        "wsproto": {
+            "hashes": [
+                "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065",
+                "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==1.2.0"
         },
         "zipp": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3cc3d6f1bfb83910f4cd9a3eb8a8807d351cfb97221e84ec2e041c63c1b4a144"
+            "sha256": "0cf55d3ee4c2c569fc7867a1dda53fd7e8aec466c5b264aab87d0249c40777b4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,11 @@
         },
         "alembic": {
             "hashes": [
-                "sha256:99bd884ca390466db5e27ffccff1d179ec5c05c965cfefc0607e69f9e411cb25",
-                "sha256:b00892b53b3642d0b8dbedba234dbf1924b69be83a9a769d5a624b01094e304b"
+                "sha256:1acdd7a3a478e208b0503cd73614d5e4c6efafa4e73518bb60e4f2846a37b1c5",
+                "sha256:496e888245a53adf1498fcab31713a469c65836f8de76e01399aa1c3e90dd213"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.14.0"
+            "version": "==1.14.1"
         },
         "amqp": {
             "hashes": [
@@ -582,19 +582,19 @@
         },
         "executing": {
             "hashes": [
-                "sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf",
-                "sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab"
+                "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa",
+                "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         },
         "faker": {
             "hashes": [
-                "sha256:49dde3b06a5602177bc2ad013149b6f60a290b7154539180d37b6f876ae79b20",
-                "sha256:ac4cf2f967ce02c898efa50651c43180bd658a7707cfd676fcc5410ad1482c03"
+                "sha256:42f2da8cf561e38c72b25e9891168b1e25fec42b6b0b5b0b6cd6041da54af885",
+                "sha256:926d2301787220e0554c2e39afc4dc535ce4b0a8d0a089657137999f66334ef4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==33.3.1"
+            "version": "==35.0.0"
         },
         "fastjsonschema": {
             "hashes": [
@@ -1014,11 +1014,11 @@
                 "opensearch2"
             ],
             "hashes": [
-                "sha256:543570b2b814cbb768c8161f1e19ddb14e5a3a5cff74317c1bcfec8c03c000df",
-                "sha256:7d1a774130f212504e491e0e4c16de2255616598084572eec7d72461006b428f"
+                "sha256:08e2d8090ff373d682f7b42f3fff506287204ee1c71b7771e80cfe8c9bc8e5e2",
+                "sha256:6cdbc658fcaf824072b9a43e2ff0564bdae6bbe8e5eb8eb2d806845ecca9f59a"
             ],
             "index": "pypi",
-            "version": "==13.0.0b1.dev24"
+            "version": "==13.0.0b2.dev1"
         },
         "invenio-assets": {
             "hashes": [
@@ -1030,11 +1030,11 @@
         },
         "invenio-banners": {
             "hashes": [
-                "sha256:82c14e5fe9999385af1ee40928afe20db2b9a82dc107be819318832603ddf0ed",
-                "sha256:a7f8c473e50437508cf63d6d07639cf7bbbf102f332cc88a67c86e5606abcebd"
+                "sha256:19a289daf297e4f1d01aa348b6ac7a02b3a171e5f0be8b3b54da0ab499f369b5",
+                "sha256:8427332f25e96073ac69ab283d5b37c427273e71768339074b0607025c31e57f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.0.0"
+            "version": "==4.1.0"
         },
         "invenio-base": {
             "hashes": [
@@ -1062,11 +1062,11 @@
         },
         "invenio-communities": {
             "hashes": [
-                "sha256:20f550ce15d1c9ca6409eec0124307231d828daa294ead60ff9a53e253d027c0",
-                "sha256:33aac9a5cf6128de777ba33b73f5cbdfd635fc114dc2ec066291489a3e8764a4"
+                "sha256:b751098c29502efc2aa988e420518f2bc7cdc328c4544bf4c523dea91e7629dd",
+                "sha256:d75ea42813945a992cfde14cae075eb2ee6e372047b063c3ef4a407ee08f3e10"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==17.7.1"
+            "version": "==18.0.0.dev2"
         },
         "invenio-config": {
             "hashes": [
@@ -1134,11 +1134,11 @@
         },
         "invenio-jobs": {
             "hashes": [
-                "sha256:7dcb9bb4f8a4b3a7f9f2c5f507000e63a967203cd3b24e46a96cca97f08ebf0b",
-                "sha256:ef091392205231b617e429eb584c4e825d4088fb77616213632efb71e871f796"
+                "sha256:07f6557addd3f02755e94c1545f68232cb24bc1ce6e7b1cde1f68cae6e9edac3",
+                "sha256:ad00c919dcedab3b043981b5c99cbd0df6bb2fd27138f17868159562df2a2b16"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.0.0.dev1"
+            "version": "==3.0.0.dev2"
         },
         "invenio-jsonschemas": {
             "hashes": [
@@ -1230,11 +1230,11 @@
         },
         "invenio-rdm-records": {
             "hashes": [
-                "sha256:a0182ec0f7029bf1fc5428f45acf5cf962bb952170efae5fd65078ee9ac96743",
-                "sha256:a8cde6f107a97a549144afd22bda495afc2c61bd46a867dff3bcde860d0aaf6a"
+                "sha256:6433bf17ee5fa03a7ccb1e64e28689b08c0012da3bc16c2f506f8a034ccb607c",
+                "sha256:d5adf5c4a200c944be5c31ab2fe187c77e17ce4556a1ca8b84ec095e83f7e2bc"
             ],
-            "index": "pypi",
-            "version": "==16.4.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==17.0.0.dev2"
         },
         "invenio-records": {
             "hashes": [
@@ -1285,11 +1285,11 @@
         },
         "invenio-requests": {
             "hashes": [
-                "sha256:2716f211a58c839c06be29d1770debe3e64ab8ec7cdf74e488e2d3d0ac739c24",
-                "sha256:63fcd56f51df311b4141b62c1efa2a3b3ac7f1b1f10989a1fca9d0e069e79d94"
+                "sha256:190f1c9baf836e2a7ceb6bfc51bad4c24a0cd7cc462abcad2043358bd6089505",
+                "sha256:43c4194daaa855003eb440f30cd98d844d8d4df2d660132a7cae2118db261ff9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.0.0.dev1"
+            "version": "==6.0.0.dev2"
         },
         "invenio-rest": {
             "hashes": [
@@ -1319,11 +1319,11 @@
         },
         "invenio-stats": {
             "hashes": [
-                "sha256:295746c334df5bdaab46134165e04b2a05c124b69b84526a324254930591866f",
-                "sha256:bafbe2f49926af043535590aa6ac00417d11a83ae6799f9c9f42fd3a81ac885e"
+                "sha256:ae45f6902a64a1f87b3ce2672fadd07e6859d2ee335ae91ac821da2aa1bff632",
+                "sha256:cfef3e19e917928384534ba7aea81a4605f3727bb943d5911a9fba332d0a6d7e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.2.1"
+            "version": "==5.1.0"
         },
         "invenio-swh": {
             "git": "https://github.com/inveniosoftware/invenio-swh",
@@ -1331,35 +1331,35 @@
         },
         "invenio-theme": {
             "hashes": [
-                "sha256:02a8d902dbf720d6b227467050e848a30751d49cf2669503462afa6e6639ba06",
-                "sha256:e5dea58cd6adc64e3861910e607787e87252baa3d6738706189ceb582a004440"
+                "sha256:5973baf9a8bce028281ccb207acb20dd99f716331a334f851a971fe58f607153",
+                "sha256:79d7c87392751a41371f24f52aa7d5ab567a436a33034dc828c2cd5f02e5ddfa"
             ],
-            "index": "pypi",
-            "version": "==3.5.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==4.1.0"
         },
         "invenio-userprofiles": {
             "hashes": [
-                "sha256:20387f0c598e7ed9798df38dc41070df8c7af32452ebbc77016001d92a2cd345",
-                "sha256:5383a20a8a14cf71fe5132f8fb83bfcc91a49d696c563310f6f6c7ff4f8f79b2"
+                "sha256:0708c82864e359a64a2d9a6402169f816cd8d297f5c7d865b748d8353afefb37",
+                "sha256:ad7183ec5f85f86fe6b2969f9ea7056ada24066452560ffb780f820cbce1693c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.0.1"
+            "version": "==4.0.0"
         },
         "invenio-users-resources": {
             "hashes": [
-                "sha256:56329d7bf02111e85b3759bf91529761631f4f95437b57f8e593419c3f9b8ccd",
-                "sha256:aaa107ab9ca4019c0b41c57c7e30649f894c0b9d72b0c72c534de3e11c4787b9"
+                "sha256:10a0d0ddcd1e318f150355d6f434f0c7cc0860b127a6e3f362956339894cc54d",
+                "sha256:98a97201c4272cf113af29a96d8985ddc18f40037278b03a985b658e19ca68cf"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.0.0.dev1"
+            "version": "==7.0.0.dev2"
         },
         "invenio-vocabularies": {
             "hashes": [
-                "sha256:340015c6accff95811b4bf85461bf7fed5e506338168fbb07cb7423035a82790",
-                "sha256:f96fa5b6eb32a17045b81a5e38960323e1785075e665663ca7bb0be79bd268b2"
+                "sha256:7164c4ccf2eed4cfed98432b05d1fab2a69b8b8a17c06f925e4d19e0400f2839",
+                "sha256:79b495ccafa790e0121ad0bf3f2af83ad64222d15aa0591d23573c4a901e9c77"
             ],
-            "index": "pypi",
-            "version": "==6.9.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==7.0.0.dev2"
         },
         "invenio-webhooks": {
             "hashes": [
@@ -1700,11 +1700,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:3a8dfda6edd8dcdbf216c0ede1d1e78d230a6dc9c5a088f58c4083b974a0d468",
-                "sha256:fece2eb2c941180ea1b7fcbd4a83c51bfdd50093fdd3ad2585ee5e1df2508491"
+                "sha256:1287bca04e6a5f4094822ac153c03da5e214a0a60bcd557b140f3e66991b8ca1",
+                "sha256:eb36762a1cc76d7abf831e18a3a1b26d3d481bbc74581b8e532a3d3a8115e1cb"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.23.1"
+            "version": "==3.26.0"
         },
         "marshmallow-oneofschema": {
             "hashes": [
@@ -2290,70 +2290,70 @@
         },
         "pyinstrument": {
             "hashes": [
-                "sha256:02b2eaf38460b14eea646d6bb7f373eb5bb5691d13f788e80bdcb3a4eaa2519e",
-                "sha256:03182ffaa9c91687cbaba80dc0c5a47015c5ea170fe642f632d88e885cf07356",
-                "sha256:0bf4ef061d60befe72366ce0ed4c75dee5be089644de38f9936d2df0bcf44af0",
-                "sha256:0c337190a1818841732643ba93065411591df526bc9de44b97ba8f56b581d2ef",
-                "sha256:0c971566d86ba46a7233d3f5b0d85d7ee4c9863f541f5d8f796c3947ebe17f68",
-                "sha256:144f98eb3086667ece461f66324bf1cc1ee0475b399ab3f9ded8449cc76b7c90",
-                "sha256:197d25487f52da3f8ec26d46db7202bc5d703cc73c1503371166417eb7cea14e",
-                "sha256:1a9b62a8b54e05e7723eb8b9595fadc43559b73290c87b3b1cb2dc5944559790",
-                "sha256:1cc236313272d0222261be8e2b2a08e42d7ccbe54db9059babf4d77040da1880",
-                "sha256:2478d2c55f77ad8e281e67b0dfe7c2176304bb824c307e86e11890f5e68d7feb",
-                "sha256:2bbab65cae1483ad8a18429511d1eac9e3efec9f7961f2fd1bf90e1e2d69ef15",
-                "sha256:39b60417c9c12eed04e1886644e92aa0b281d72e5d0b097b16253cade43110f7",
-                "sha256:3b1f44a34da7810938df615fb7cbc43cd879b42ca6b5cd72e655aee92149d012",
-                "sha256:40a8485c2e41082a20822001a6651667bb5327f6f5f6759987198593e45bb376",
-                "sha256:429376235960179d6ab9b97e7871090059d39de160b4e3b2723672f30e8eea8e",
-                "sha256:4351ad041d208c597e296a0e9c2e6e21cc96804608bcafa40cfa168f3c2b8f79",
-                "sha256:4cecd0f6558f13fba74a9f036b2b168956206e9525dcb84c6add2d73ab61dc22",
-                "sha256:4d3b2ec6e028731dbb2ba8cf06f19030162789e6696bca990a09519881ad42fb",
-                "sha256:4fd94cc725efb1dd41ae8e20a5f06a6a5363dec959e8a9dacbac3f4d12d28f03",
-                "sha256:5a39e3ef84c56183f8274dfd584b8c2fae4783c6204f880513e70ab2440b9137",
-                "sha256:5d34c06e2276d1f549a540bccb063688ea3d876e6df7c391205f1c8b4b96d5c8",
-                "sha256:5ed6f5873a7526ec5915e45d956d044334ef302653cf63649e48c41561aaa285",
-                "sha256:68001dfcb8a37b624a1c3de5d2ee7d634f63eac7a6dd1357b7370a5cdbdcf567",
-                "sha256:6a83cf18f5594e1b1899b12b46df7aabca556eef895846ccdaaa3a46a37d1274",
-                "sha256:6dd685d68a31f3715ca61f82c37c1c2f8b75f45646bd9840e04681d91862bd85",
-                "sha256:6f6bac8a434407de6f2ebddbcdecdb19b324c9315cbb8b8c2352714f7ced8181",
-                "sha256:79a54def2d4aa83a4ed37c6cffc5494ae5de140f0453169eb4f7c744cc249d3a",
-                "sha256:7bb389b6d1573361bd1367b296133c5c69184e35fc18db22e29e8cdf56f158f9",
-                "sha256:7ccf4267aff62de0e1d976e8f5da25dcb69737ae86e38d3cfffa24877837e7d1",
-                "sha256:7d87ddab66b1b3525ad3abc49a88aaa51efcaf83578e9d2a702c03a1cea39f28",
-                "sha256:7e8dc887e535f5c5e5a2a64a0729496f11ddcef0c23b0a555d5ab6fa19759445",
-                "sha256:80d2a248516f372a89e0fe9ddf4a9d6388a4c6481b6ebd3dfe01b3cd028c0275",
-                "sha256:8284bf8847629c9a5054702b9306eab3ab14c2474959e01e606369ffbcf938bc",
-                "sha256:83caeb4150c0334e9e290c0f9bb164ff6bdc199065ecb62016268e8a88589a51",
-                "sha256:8599b4b0630c776b30fc3c4f7476d5e3814ee7fe42d99131644fe3c00b40fdf1",
-                "sha256:8d2a7279ed9b6d7cdae247bc2e57095a32f35dfe32182c334ab0ac3eb02e0eac",
-                "sha256:9538f746f166a40c8802ebe5c3e905d50f3faa189869cd71c083b8a639e574bb",
-                "sha256:9e87d65bae7d0f5ef50908e35d67d43b7cc566909995cc99e91721bb49b4ea06",
-                "sha256:9ffe938e63173ceb8ce7b6b309ce26c9d44d16f53c0162d89d6e706eb9e69802",
-                "sha256:a072d928dc16a32e0f3d1e51726f4472a69d66d838ee1d1bf248737fd70b9415",
-                "sha256:a164f3dae5c7db2faa501639659d64034cde8db62a4d6744712593a369bc8629",
-                "sha256:a6294b7111348765ba4c311fc91821ed8b59c6690c4dab23aa7165a67da9e972",
-                "sha256:a8bc688afa2a5368042a7cb56866d5a28fdff8f37a282f7be79b17cae042841b",
-                "sha256:ae69478815edb3c63e7ebf82e1e13e38c3fb2bab833b1c013643c3475b1b8cf5",
-                "sha256:b3050a4e7033103a13cfff9802680e2070a9173e1a258fa3f15a80b4eb9ee278",
-                "sha256:b3938f063ee065e05826628dadf1fb32c7d26b22df4a945c22f7fe25ea1ba6a2",
-                "sha256:b69ff982acf5ef2f4e0f32ce9b4b598f256faf88438f233ea3a72f1042707e5b",
-                "sha256:bd953163616bc29c2ccb1e4c0e48ccdd11e0a97fc849da26bc362bba372019ba",
-                "sha256:c2c7ae2c984879a645fce583bf3053b7e57495f60c1e158bb71ad7dfced1fbf1",
-                "sha256:c2e3b4283f85232fd5818e2153e6798bceb39a8c3ccfaa22fae08faf554740b7",
-                "sha256:c9052f548ec5ccecc50676fbf1a1d0b60bdbd3cd67630c5253099af049d1f0ad",
-                "sha256:ceee5252f4580abec29bcc5c965453c217b0d387c412a5ffb8afdcda4e648feb",
-                "sha256:d5c4c3cc6410ad5afe0e352a7fb09fb1ab85eb5676ec5ec8522123759d9cc68f",
-                "sha256:ddaa3001c1b798ec9bf1266ef476bbc0834b74d547d531f5ed99e7d05ac5d81b",
-                "sha256:dec3529a5351ea160baeef1ef2a6e28b1a7a7b3fb5e9863fae8de6da73d0f69a",
-                "sha256:e0fdb9fe6f9c694940410dcc82e23a3fe2928114328efd35047fc0bb8a6c959f",
-                "sha256:e57db06590f13657b2bce8c4d9cf8e9e2bd90bb729bcbbe421c531ba67ad7add",
-                "sha256:f18990cc16b2e23b54738aa2f222863e1d36daaaec8f67b1613ddfa41f5b24db",
-                "sha256:f3731412b5bfdcef8014518f145140c69384793e218863a33a39ccfe5fb42045",
-                "sha256:fb1139d2822abff1cbf1c81c018341f573b7afa23a94ce74888a0f6f47828cbc",
-                "sha256:fde075196c8a3b2be191b8da05b92ff909c78d308f82df56d01a8cfdd6da07b9"
+                "sha256:000de38068c10769ce9268955191df2738b065e606b5a3453077e31c0db96259",
+                "sha256:0519d02dee55a87afcf6d787f8d8f5a16d2b89f7ba9533064a986a2d31f27340",
+                "sha256:0a196ae4e0eeacdbde0f1d1f04ea75d249021b90a924f7611013b131e48a5a15",
+                "sha256:0e0197702dab98ef7da02a9e1def0b9b04659ac09a67266791b096837d0d3f68",
+                "sha256:20f8054e85dd710f5a8c4d6b738867366ceef89671db09c87690ba1b5c66bd67",
+                "sha256:219ed803f5e3887a9f345ec73c9e2b1f76e993202bc8f9c46a681cda2b7040f6",
+                "sha256:248dc2d016fe935ae7365cd0f83f9d32a7285593f23b703b363c2db9f126983f",
+                "sha256:2991309f3e25546e9bc06f36c20580fb64ad48ce7be2fd63db11a11d6c67c880",
+                "sha256:29ff672575fc44ca775c1bd6d5871323d6e8e3b5ad49791107b750be682e5865",
+                "sha256:2f59ed9ac9466ff9b30eb7285160fa794aa3f8ce2bcf58a94142f945882d28ab",
+                "sha256:373857279f297a6dca5fd4c25aea1a0ead2b66d6f90ce8c1f9c27d1f0bb08fc2",
+                "sha256:442c763c8311557062a7ad20f9edd77600182cb14cd9fcb207cdf947d42038bb",
+                "sha256:47959cd63cfc0559639199a4a88c871790cd7f0a0f9043057e7408048c035319",
+                "sha256:5031821ca602a4f31b87edd4076cfc313ed4a1d1d052ff71092e98ee216e225e",
+                "sha256:5813b2a9e0c44fc1e8f45fe5492aab055851def74bc2ff12e2aff50d57df32d6",
+                "sha256:5bd835d7e3f1da1e7ac96b751012da09d13dd673750e49b051907f10d0f1b8c4",
+                "sha256:63e8d75ffa50c3cf6d980844efce0334659e934dcc3832bad08c23c171c545ff",
+                "sha256:6afe94a27a9016b365b9dd3a5f03732a3cd29d8bcb178113b09e73d36cf51196",
+                "sha256:6e6f5655d580429e7992c37757cc5f6e74ca81b0f2768b833d9711631a8cb2f7",
+                "sha256:70b16b5915534d8df40dcf04a7cc78d3290464c06fa358a4bc324280af4c74e0",
+                "sha256:7387acabf1eb74b7a0deead0d5ad3b1a41c2c7b2d7c9b5507047f04700d0b446",
+                "sha256:81b7192c7dc956923829355a85ac361f2409093a3f998e8a0294ffd447863526",
+                "sha256:820b30b5c3f9c1be5d203e79e1dddee3d1fcb275cd85e5c7cc52583909404ca4",
+                "sha256:823d2022c47b8d635f0d8ec6dfd36eb3d50a77abfcabc32aa6d3cdea8eea3fe9",
+                "sha256:835ecac9061ce8926321276b47b7d17a6ae19a932d33c5ef7be632a83a07f78a",
+                "sha256:84e37ffabcf26fe820d354a1f7e9fc26949f953addab89b590c5000b3ffa60d0",
+                "sha256:86f20b680223697a8ac5c061fb40a63d3ee519c7dfb1097627bd4480711216d9",
+                "sha256:8ceee4fa6c24c5a1c346ee641b50f63438cf76bf25d2e86ee6fbfe5d505e00e6",
+                "sha256:8f1b7d6d4b9d1ed1b9e222352421a5b080a87b9e6b7cd654b9ba94c5c8266286",
+                "sha256:8f3af11d4219360b89307581ea204fde476c6f5ab91afc932c34655f0974ed6f",
+                "sha256:967f84bd82f14425543a983956ff9cfcf1e3762755ffcec8cd835c6be22a7a0a",
+                "sha256:9bdded62e0a6878a4a061d6cfdd9ec92a1ec1002776688a90f0b5329938a087b",
+                "sha256:9f54285f0924d443dd27f0510693a76ecafd6d38573be2254b3c86314db42efe",
+                "sha256:a0d23d3763ec95da0beb390c2f7df7cbe36ea62b6a4d5b89c4eaab81c1c649cf",
+                "sha256:a14d3a90c432f1ce1be91716fa76b75dc74ed03100282878d2a4d30c7c75c980",
+                "sha256:a3ca9c8540051513dd633de9d7eac9fee2eda50b78b6eedeaa7e5a7be66026b5",
+                "sha256:a3f16a0bde13a4ac1b8fdbcaf49626926e523028bd68804caa186ba9e9c51d09",
+                "sha256:a5f0a468382198b84991e83beff7c43e9315f974379b17abcc285caff154bdfc",
+                "sha256:a876d6f6d6ad7840be62d2eeb8af868d3bf9ab0b023e082a79b22909bce7c755",
+                "sha256:b4c8c9ad93f62f0bf2ddc7fb6fce3a91c008d422873824e01c5e5e83467fd1fb",
+                "sha256:b549d910b846757ffbf74d94528d1a694a3848a6cfc6a6cab2ce697ee71e4548",
+                "sha256:b5d20802b0c2bd1ddb95b2e96ebd3e9757dbab1e935792c2629166f1eb267bb2",
+                "sha256:c0e26a6fc51f259882b621a13ec2736a4788a57e304a102aee1bf0401eb29ce2",
+                "sha256:c803f7b880394b7bba5939ff8a59d6962589e9a0140fc33c3a6a345c58846106",
+                "sha256:cbf3114d332e499ba35ca4aedc1ef95bc6fb15c8d819729b5c0aeb35c8b64dd2",
+                "sha256:cbfdc71be2dd8e5a8a349df0430e4908897ced448a2f2c50c1cac493cd2565b5",
+                "sha256:cc1d22bbeea51c5a2f5f119be6320707a7836b7a3a09fae4ace7ac25375ee9ce",
+                "sha256:cfd7b7dc56501a1f30aa059cc2f1746ece6258a841d2e4609882581f9c17f824",
+                "sha256:d18e37baaaae969f3cf5b3187db386de7f458a8393f6825564ebb6e51714363a",
+                "sha256:d29093f7fd419aa26c0ef5a81dfed80cbe48799d9ab977f343570a6864ce76e2",
+                "sha256:dabda1485011aa2bfa6cb293020f2e35163ccc3b2746c1e72ff0ea5e62dfe730",
+                "sha256:db15d1854b360182d242da8de89761a0ffb885eea61cb8652e40b5b9a4ef44bc",
+                "sha256:de3a7b81236f893fb43aa428db9919a1fbc8ccb47c2428ade1fc2a6b96e007ec",
+                "sha256:e025b301767fadcf9c2525461d2f979b0c9bff402122771522e5906ce47a8352",
+                "sha256:ea1030351d43ea35fb70939540b08c3d9e0e6aaa1cd9e7c62ed410c039af0206",
+                "sha256:ed712b88fe6f0dbd4a1966d4254e546545e512dc3b69329c74aded0c7e7baff2",
+                "sha256:f4fd0754d02959c113a4b1ebed02f4627b6e2c138719ddf43244fd95f201c8c9",
+                "sha256:f5065639dfedc3b8e537161f9aaa8c550c8717c935a962e9bf1e843bf0e8791f",
+                "sha256:f5ee80ac5e7821c28458b19ca61b082e1f71f1171e2c5da700e07e21c114fd31",
+                "sha256:fe1f33178a2b0ddb3c6d2321406228bdad41286774e65314d511dcf4a71b83e4",
+                "sha256:fe85109415bc63e2cc22144e6c6202b99a8087dc54330abf6d1067c775c6eb54"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==5.0.0"
+            "version": "==5.0.1"
         },
         "pyjwt": {
             "extras": [
@@ -2368,11 +2368,11 @@
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:49f81412242d3527b8b4967b990df395c89563043bc51a3d2d7d500e52123b77",
-                "sha256:b0ee1e0b2bef1071a47891ab17003bfe5bf824a398e13f49f8ed653b699369a7"
+                "sha256:637951cbfbe9874ba28134fb3ce4b8bcadd6aca89ac4998ec29dcbafd554ae08",
+                "sha256:b65801996a0cd4f42a3110810c306c45b7313c09b0610a6f773730f2a9e3c96b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.12"
+            "version": "==10.14.1"
         },
         "pymysql": {
             "hashes": [
@@ -3115,66 +3115,66 @@
                 "asyncio"
             ],
             "hashes": [
-                "sha256:03e08af7a5f9386a43919eda9de33ffda16b44eb11f3b313e6822243770e9763",
-                "sha256:0572f4bd6f94752167adfd7c1bed84f4b240ee6203a95e05d1e208d488d0d436",
-                "sha256:07b441f7d03b9a66299ce7ccf3ef2900abc81c0db434f42a5694a37bd73870f2",
-                "sha256:1bc330d9d29c7f06f003ab10e1eaced295e87940405afe1b110f2eb93a233588",
-                "sha256:1e0d612a17581b6616ff03c8e3d5eff7452f34655c901f75d62bd86449d9750e",
-                "sha256:23623166bfefe1487d81b698c423f8678e80df8b54614c2bf4b4cfcd7c711959",
-                "sha256:2519f3a5d0517fc159afab1015e54bb81b4406c278749779be57a569d8d1bb0d",
-                "sha256:28120ef39c92c2dd60f2721af9328479516844c6b550b077ca450c7d7dc68575",
-                "sha256:37350015056a553e442ff672c2d20e6f4b6d0b2495691fa239d8aa18bb3bc908",
-                "sha256:39769a115f730d683b0eb7b694db9789267bcd027326cccc3125e862eb03bfd8",
-                "sha256:3c01117dd36800f2ecaa238c65365b7b16497adc1522bf84906e5710ee9ba0e8",
-                "sha256:3d6718667da04294d7df1670d70eeddd414f313738d20a6f1d1f379e3139a545",
-                "sha256:3dbb986bad3ed5ceaf090200eba750b5245150bd97d3e67343a3cfed06feecf7",
-                "sha256:4557e1f11c5f653ebfdd924f3f9d5ebfc718283b0b9beebaa5dd6b77ec290971",
-                "sha256:46331b00096a6db1fdc052d55b101dbbfc99155a548e20a0e4a8e5e4d1362855",
-                "sha256:4a121d62ebe7d26fec9155f83f8be5189ef1405f5973ea4874a26fab9f1e262c",
-                "sha256:4f5e9cd989b45b73bd359f693b935364f7e1f79486e29015813c338450aa5a71",
-                "sha256:50aae840ebbd6cdd41af1c14590e5741665e5272d2fee999306673a1bb1fdb4d",
-                "sha256:59b1ee96617135f6e1d6f275bbe988f419c5178016f3d41d3c0abb0c819f75bb",
-                "sha256:59b8f3adb3971929a3e660337f5dacc5942c2cdb760afcabb2614ffbda9f9f72",
-                "sha256:66bffbad8d6271bb1cc2f9a4ea4f86f80fe5e2e3e501a5ae2a3dc6a76e604e6f",
-                "sha256:69f93723edbca7342624d09f6704e7126b152eaed3cdbb634cb657a54332a3c5",
-                "sha256:6a440293d802d3011028e14e4226da1434b373cbaf4a4bbb63f845761a708346",
-                "sha256:72c28b84b174ce8af8504ca28ae9347d317f9dba3999e5981a3cd441f3712e24",
-                "sha256:79d2e78abc26d871875b419e1fd3c0bca31a1cb0043277d0d850014599626c2e",
-                "sha256:7f2767680b6d2398aea7082e45a774b2b0767b5c8d8ffb9c8b683088ea9b29c5",
-                "sha256:8318f4776c85abc3f40ab185e388bee7a6ea99e7fa3a30686580b209eaa35c08",
-                "sha256:8958b10490125124463095bbdadda5aa22ec799f91958e410438ad6c97a7b793",
-                "sha256:8c78ac40bde930c60e0f78b3cd184c580f89456dd87fc08f9e3ee3ce8765ce88",
-                "sha256:90812a8933df713fdf748b355527e3af257a11e415b613dd794512461eb8a686",
-                "sha256:9bc633f4ee4b4c46e7adcb3a9b5ec083bf1d9a97c1d3854b92749d935de40b9b",
-                "sha256:9e46ed38affdfc95d2c958de328d037d87801cfcbea6d421000859e9789e61c2",
-                "sha256:9fe53b404f24789b5ea9003fc25b9a3988feddebd7e7b369c8fac27ad6f52f28",
-                "sha256:a4e46a888b54be23d03a89be510f24a7652fe6ff660787b96cd0e57a4ebcb46d",
-                "sha256:a86bfab2ef46d63300c0f06936bd6e6c0105faa11d509083ba8f2f9d237fb5b5",
-                "sha256:ac9dfa18ff2a67b09b372d5db8743c27966abf0e5344c555d86cc7199f7ad83a",
-                "sha256:af148a33ff0349f53512a049c6406923e4e02bf2f26c5fb285f143faf4f0e46a",
-                "sha256:b11d0cfdd2b095e7b0686cf5fabeb9c67fae5b06d265d8180715b8cfa86522e3",
-                "sha256:b2985c0b06e989c043f1dc09d4fe89e1616aadd35392aea2844f0458a989eacf",
-                "sha256:b544ad1935a8541d177cb402948b94e871067656b3a0b9e91dbec136b06a2ff5",
-                "sha256:b5cc79df7f4bc3d11e4b542596c03826063092611e481fcf1c9dfee3c94355ef",
-                "sha256:b817d41d692bf286abc181f8af476c4fbef3fd05e798777492618378448ee689",
-                "sha256:b81ee3d84803fd42d0b154cb6892ae57ea6b7c55d8359a02379965706c7efe6c",
-                "sha256:be9812b766cad94a25bc63bec11f88c4ad3629a0cec1cd5d4ba48dc23860486b",
-                "sha256:c245b1fbade9c35e5bd3b64270ab49ce990369018289ecfde3f9c318411aaa07",
-                "sha256:c3f3631693003d8e585d4200730616b78fafd5a01ef8b698f6967da5c605b3fa",
-                "sha256:c4ae3005ed83f5967f961fd091f2f8c5329161f69ce8480aa8168b2d7fe37f06",
-                "sha256:c54a1e53a0c308a8e8a7dffb59097bff7facda27c70c286f005327f21b2bd6b1",
-                "sha256:d0ddd9db6e59c44875211bc4c7953a9f6638b937b0a88ae6d09eb46cced54eff",
-                "sha256:dc022184d3e5cacc9579e41805a681187650e170eb2fd70e28b86192a479dcaa",
-                "sha256:e32092c47011d113dc01ab3e1d3ce9f006a47223b18422c5c0d150af13a00687",
-                "sha256:f7b64e6ec3f02c35647be6b4851008b26cff592a95ecb13b6788a54ef80bbdd4",
-                "sha256:f942a799516184c855e1a32fbc7b29d7e571b52612647866d4ec1c3242578fcb",
-                "sha256:f9511d8dd4a6e9271d07d150fb2f81874a3c8c95e11ff9af3a2dfc35fe42ee44",
-                "sha256:fd3a55deef00f689ce931d4d1b23fa9f04c880a48ee97af488fd215cf24e2a6c",
-                "sha256:fddbe92b4760c6f5d48162aef14824add991aeda8ddadb3c31d56eb15ca69f8e",
-                "sha256:fdf3386a801ea5aba17c6410dd1dc8d39cf454ca2565541b5ac42a84e1e28f53"
+                "sha256:03f0528c53ca0b67094c4764523c1451ea15959bbf0a8a8a3096900014db0278",
+                "sha256:12b0f1ec623cccf058cf21cb544f0e74656618165b083d78145cafde156ea7b6",
+                "sha256:12b28d99a9c14eaf4055810df1001557176716de0167b91026e648e65229bffb",
+                "sha256:1b2690456528a87234a75d1a1644cdb330a6926f455403c8e4f6cad6921f9098",
+                "sha256:1cdba1f73b64530c47b27118b7053b8447e6d6f3c8104e3ac59f3d40c33aa9fd",
+                "sha256:293f9ade06b2e68dd03cfb14d49202fac47b7bb94bffcff174568c951fbc7af2",
+                "sha256:2952748ecd67ed3b56773c185e85fc084f6bdcdec10e5032a7c25a6bc7d682ef",
+                "sha256:2f95fc8e3f34b5f6b3effb49d10ac97c569ec8e32f985612d9b25dd12d0d2e94",
+                "sha256:2fa2c0913f02341d25fb858e4fb2031e6b0813494cca1ba07d417674128ce11b",
+                "sha256:3151822aa1db0eb5afd65ccfafebe0ef5cda3a7701a279c8d0bf17781a793bb4",
+                "sha256:35bd2df269de082065d4b23ae08502a47255832cc3f17619a5cea92ce478b02b",
+                "sha256:41296bbcaa55ef5fdd32389a35c710133b097f7b2609d8218c0eabded43a1d84",
+                "sha256:44f569d0b1eb82301b92b72085583277316e7367e038d97c3a1a899d9a05e342",
+                "sha256:46954173612617a99a64aee103bcd3f078901b9a8dcfc6ae80cbf34ba23df989",
+                "sha256:4b12885dc85a2ab2b7d00995bac6d967bffa8594123b02ed21e8eb2205a7584b",
+                "sha256:4f581d365af9373a738c49e0c51e8b18e08d8a6b1b15cc556773bcd8a192fa8b",
+                "sha256:51bc9cfef83e0ac84f86bf2b10eaccb27c5a3e66a1212bef676f5bee6ef33ebb",
+                "sha256:521ef85c04c33009166777c77e76c8a676e2d8528dc83a57836b63ca9c69dcd1",
+                "sha256:5bc3339db84c5fb9130ac0e2f20347ee77b5dd2596ba327ce0d399752f4fce39",
+                "sha256:635d8a21577341dfe4f7fa59ec394b346da12420b86624a69e466d446de16aff",
+                "sha256:648ec5acf95ad59255452ef759054f2176849662af4521db6cb245263ae4aa33",
+                "sha256:650dcb70739957a492ad8acff65d099a9586b9b8920e3507ca61ec3ce650bb72",
+                "sha256:6b788f14c5bb91db7f468dcf76f8b64423660a05e57fe277d3f4fad7b9dcb7ce",
+                "sha256:6c67415258f9f3c69867ec02fea1bf6508153709ecbd731a982442a590f2b7e4",
+                "sha256:74bbd1d0a9bacf34266a7907d43260c8d65d31d691bb2356f41b17c2dca5b1d0",
+                "sha256:75311559f5c9881a9808eadbeb20ed8d8ba3f7225bef3afed2000c2a9f4d49b9",
+                "sha256:78361be6dc9073ed17ab380985d1e45e48a642313ab68ab6afa2457354ff692c",
+                "sha256:7b7e772dc4bc507fdec4ee20182f15bd60d2a84f1e087a8accf5b5b7a0dcf2ba",
+                "sha256:82df02816c14f8dc9f4d74aea4cb84a92f4b0620235daa76dde002409a3fbb5a",
+                "sha256:84b9f23b0fa98a6a4b99d73989350a94e4a4ec476b9a7dfe9b79ba5939f5e80b",
+                "sha256:8c4096727193762e72ce9437e2a86a110cf081241919ce3fab8e89c02f6b6658",
+                "sha256:8e47f1af09444f87c67b4f1bb6231e12ba6d4d9f03050d7fc88df6d075231a49",
+                "sha256:93d1543cd8359040c02b6614421c8e10cd7a788c40047dbc507ed46c29ae5636",
+                "sha256:94b564e38b344d3e67d2e224f0aec6ba09a77e4582ced41e7bfd0f757d926ec9",
+                "sha256:955a2a765aa1bd81aafa69ffda179d4fe3e2a3ad462a736ae5b6f387f78bfeb8",
+                "sha256:9d087663b7e1feabea8c578d6887d59bb00388158e8bff3a76be11aa3f748ca2",
+                "sha256:9df21b8d9e5c136ea6cde1c50d2b1c29a2b5ff2b1d610165c23ff250e0704087",
+                "sha256:a8998bf9f8658bd3839cbc44ddbe982955641863da0c1efe5b00c1ab4f5c16b1",
+                "sha256:b2eae3423e538c10d93ae3e87788c6a84658c3ed6db62e6a61bb9495b0ad16bb",
+                "sha256:b661b49d0cb0ab311a189b31e25576b7ac3e20783beb1e1817d72d9d02508bf5",
+                "sha256:bedee60385c1c0411378cbd4dc486362f5ee88deceea50002772912d798bb00f",
+                "sha256:c505edd429abdfe3643fa3b2e83efb3445a34a9dc49d5f692dd087be966020e0",
+                "sha256:cce918ada64c956b62ca2c2af59b125767097ec1dca89650a6221e887521bfd7",
+                "sha256:cf5ae8a9dcf657fd72144a7fd01f243236ea39e7344e579a121c4205aedf07bb",
+                "sha256:cf95a60b36997dad99692314c4713f141b61c5b0b4cc5c3426faad570b31ca01",
+                "sha256:d57bafbab289e147d064ffbd5cca2d7b1394b63417c0636cea1f2e93d16eb9e8",
+                "sha256:d70f53a0646cc418ca4853da57cf3ddddbccb8c98406791f24426f2dd77fd0e2",
+                "sha256:d75ead7dd4d255068ea0f21492ee67937bd7c90964c8f3c2bea83c7b7f81b95f",
+                "sha256:da36c3b0e891808a7542c5c89f224520b9a16c7f5e4d6a1156955605e54aef0e",
+                "sha256:db18ff6b8c0f1917f8b20f8eca35c28bbccb9f83afa94743e03d40203ed83de9",
+                "sha256:dfff7be361048244c3aa0f60b5e63221c5e0f0e509f4e47b8910e22b57d10ae7",
+                "sha256:e4fb5ac86d8fe8151966814f6720996430462e633d225497566b3996966b9bdb",
+                "sha256:e56a139bfe136a22c438478a86f8204c1eb5eed36f4e15c4224e4b9db01cb3e4",
+                "sha256:e6f5d254a22394847245f411a2956976401e84da4288aa70cbcd5190744062c1",
+                "sha256:e7402ff96e2b073a98ef6d6142796426d705addd27b9d26c3b32dbaa06d7d069",
+                "sha256:ea308cec940905ba008291d93619d92edaf83232ec85fbd514dcb329f3192761",
+                "sha256:eaa8039b6d20137a4e02603aba37d12cd2dde7887500b8855356682fc33933f4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.36"
+            "version": "==2.0.37"
         },
         "sqlalchemy-continuum": {
             "hashes": [
@@ -3348,11 +3348,11 @@
         },
         "types-pyyaml": {
             "hashes": [
-                "sha256:392b267f1c0fe6022952462bf5d6523f31e37f6cea49b14cee7ad634b6301570",
-                "sha256:d1405a86f9576682234ef83bcb4e6fff7c9305c8b1fbad5e0bcd4f7dbdc9c587"
+                "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c",
+                "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==6.0.12.20240917"
+            "version": "==6.0.12.20241230"
         },
         "types-requests": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c6004ab48e7429969926332e8cda084461fb00c05e9c28734405c6597b99f9db"
+            "sha256": "3cc3d6f1bfb83910f4cd9a3eb8a8807d351cfb97221e84ec2e041c63c1b4a144"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,11 @@
         },
         "alembic": {
             "hashes": [
-                "sha256:295b54bbb92c4008ab6a7dcd1e227e668416d6f84b98b3c4446a2bc6214a556b",
-                "sha256:43942c3d4bf2620c466b91c0f4fca136fe51ae972394a0cc8b90810d664e4f5c"
+                "sha256:99bd884ca390466db5e27ffccff1d179ec5c05c965cfefc0607e69f9e411cb25",
+                "sha256:b00892b53b3642d0b8dbedba234dbf1924b69be83a9a769d5a624b01094e304b"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.10.4"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.14.0"
         },
         "amqp": {
             "hashes": [
@@ -172,11 +172,11 @@
         },
         "celery": {
             "hashes": [
-                "sha256:870cc71d737c0200c397290d730344cc991d13a057534353d124c9380267aab9",
-                "sha256:9da4ea0118d232ce97dff5ed4974587fb1c0ff5c10042eb15278487cdd27d1af"
+                "sha256:369631eb580cf8c51a82721ec538684994f8277637edde2dfc0dacd73ed97f64",
+                "sha256:504a19140e8d3029d5acad88330c541d4c3f64c789d85f94756762d8bca7e706"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==5.3.6"
+            "version": "==5.4.0"
         },
         "certifi": {
             "hashes": [
@@ -605,18 +605,19 @@
         },
         "flask": {
             "hashes": [
-                "sha256:58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf",
-                "sha256:edee9b0a7ff26621bd5a8c10ff484ae28737a2410d99b0bb9a6850c7fb977aa0"
+                "sha256:5f873c5184c897c8d9d1b05df1e3d01b14910ce69607a117bd3277098a5836ac",
+                "sha256:d667207822eb83f1c4b50949b1623c8fc8d51f2341d65f72e1a1815397551136"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.2.5"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.0"
         },
         "flask-alembic": {
             "hashes": [
-                "sha256:05a1e6f4148dbfcc9280a393373bfbd250af6f9f4f0ca9f744ef8f7376a3deec",
-                "sha256:7e67740b0b08d58dcae0c701d56b56e60f5fa4af907bb82b4cb0469229ba94ff"
+                "sha256:1d0cda58518d4332d8563da555bee03107fe2169c7157f61a2e0759d0150209b",
+                "sha256:358a0ad8f74e2969273a8d89feaf5842f65cc909064b51fde4b51415790d92f4"
             ],
-            "version": "==2.0.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.1"
         },
         "flask-babel": {
             "hashes": [
@@ -695,18 +696,19 @@
         },
         "flask-menu": {
             "hashes": [
-                "sha256:d161908630dc899040325746db0e9e47d8a08732f14bc17b599b32cf1be50b0a",
-                "sha256:d34c92004c3149e07d4f4636e33bc0fbace7a2f9a75b64c055ef8cb8cb799c0a"
+                "sha256:162b409e444bea4ab10f12ab1270dd3d62dc0bd1f3d43b3e964a931019f5d580",
+                "sha256:bd9a4c9c4241300aa05e3f27da7d8953f197d4591763a2e0495381b7d9713efa"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.0.1"
+            "version": "==2.0.0"
         },
-        "flask-oauthlib": {
+        "flask-oauthlib-invenio": {
             "hashes": [
-                "sha256:5bb79c8a8e670c2eb4cb553dfc3283b6c8d1202f674934676dc173cee94fe39c",
-                "sha256:a5c3b62959aa1922470a62b6ebf4273b75f1c29561a7eb4a69cde85d45a1d669"
+                "sha256:1258a40ea8ad92f45f1bc69c81439718528e0be6fd829326d7a02cd12b858d9d",
+                "sha256:676557441504831bae028a925a47af267fd8d743185655785a99b61962ce3792"
             ],
-            "version": "==0.9.6"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.1.1"
         },
         "flask-principal": {
             "hashes": [
@@ -747,11 +749,11 @@
         },
         "flask-sqlalchemy": {
             "hashes": [
-                "sha256:2bda44b43e7cacb15d4e05ff3cc1f8bc97936cc464623424102bfc2c35e95912",
-                "sha256:f12c3d4cc5cc7fdcc148b9527ea05671718c3ea45d50c7e732cceb33f574b390"
+                "sha256:4ba4be7f419dc72f4efd8802d69974803c37259dd42f3913b0dcf75c9447e0a0",
+                "sha256:e4b68bb881802dda1a7d878b2fc84c06d1ee57fb40b874d3dc97dabfa36b8312"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.5.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.1.1"
         },
         "flask-talisman": {
             "hashes": [
@@ -977,94 +979,94 @@
         },
         "invenio-access": {
             "hashes": [
-                "sha256:208aa4afc114134614c0c593f72100d750b2ea28192d97272addb246697b087e",
-                "sha256:f2ce61e4dd6fc1dda60ea89fdc8691f2510ae7f156491f1e1b16a4dcd9244e3e"
+                "sha256:9faf0ee20f6e28f5300f5f0ca01675249607befe1ac3ec34647473aae89c504d",
+                "sha256:b8e7a1778b24b5dc690e9784e6d67ae421d86687a61dd11619ec332c362b5f66"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.0.2"
+            "version": "==4.0.0"
         },
         "invenio-accounts": {
             "hashes": [
-                "sha256:279a1e08e4abebc790c2a2977b9ab1f051880bbc47d4823be058cc60a3e505c7",
-                "sha256:a715360207f8a284e5182c29ab48e4e5d1aa7180d62b548ff300772adbfa97a5"
+                "sha256:5aee749ba745787c5851fb4a548755a1c72f8f696798110cfe2ce4c1623b7d7d",
+                "sha256:8ac9429cdfc113a5dc3e06ec36b77a8727b9626f485ff2ffbc7d8f7df9f48067"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.1.7"
+            "version": "==6.0.0"
         },
         "invenio-administration": {
             "hashes": [
-                "sha256:1efe46ab78663b6611cfd5cd59632e74d859e22818e36bd2a6b10ce16cf89ea2",
-                "sha256:e3c5cd20de3a423f7a0953b6b9fdfa512aef88522feee9ba931c3be81344ac7b"
+                "sha256:c397883e00af3667e4123f2ae89b5bcee86a3c65c433e3fa4c5cabc783f78ed7",
+                "sha256:d7872a38f258cb858b3d2c20245df81a88ba2df5573bfbaea391e54ba5540e90"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.9.0"
+            "version": "==3.0.0"
         },
         "invenio-app": {
             "hashes": [
-                "sha256:5350b549203a813d07dfb383d672d709abb48463482e0780a5139fe44e935b3c",
-                "sha256:e22a3c08ffe57b992eecf05346bb3346571fca492babae2b065a089e73df5bfb"
+                "sha256:04e1a50078b0bd5145b23d096b02cb0a1991981798296a7e14eae862ff4cba53",
+                "sha256:66462955a6d05f66accc18f47548291e6b24b0d1df4bc1c5315c9684790980f2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.5.1"
+            "version": "==2.0.0"
         },
         "invenio-app-rdm": {
             "extras": [
                 "opensearch2"
             ],
             "hashes": [
-                "sha256:5ec80bab54aad9d85589e80110d4f7d143b2fcc309ea5a9e1f4fe73331b03e8f",
-                "sha256:fc698f96829ee03979a457a25a82276eb4c060d43586353018be7f1c5e713b45"
+                "sha256:543570b2b814cbb768c8161f1e19ddb14e5a3a5cff74317c1bcfec8c03c000df",
+                "sha256:7d1a774130f212504e491e0e4c16de2255616598084572eec7d72461006b428f"
             ],
             "index": "pypi",
-            "version": "==13.0.0b1.dev28"
+            "version": "==13.0.0b1.dev24"
         },
         "invenio-assets": {
             "hashes": [
-                "sha256:0641235db3687941f486f8cb2c0a59186130c2db79b7ec459ef10e6e736c36bd",
-                "sha256:0e5d86363a7088353ca24dce63df87278d82c98ada80db79222530cdac19aa6c"
+                "sha256:12e821fabd938bbc3081c07fa03cbbc95626ec0a036c7ae530e75ab16139d1d2",
+                "sha256:e1af01df678b3bbdd9c352c39710699df6d477e7a9fbcea7fe75b1c30cf07157"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.0"
+            "version": "==4.0.0"
         },
         "invenio-banners": {
             "hashes": [
-                "sha256:671f9765a0a5ddab81a27c796319759a1f72a1dbde8574303439fba19ff35452",
-                "sha256:fb4f78b14b52db45069643deee511d6dd42b23f03f9d5b44202e6d17588c53f1"
+                "sha256:82c14e5fe9999385af1ee40928afe20db2b9a82dc107be819318832603ddf0ed",
+                "sha256:a7f8c473e50437508cf63d6d07639cf7bbbf102f332cc88a67c86e5606abcebd"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.2.0"
+            "version": "==4.0.0"
         },
         "invenio-base": {
             "hashes": [
-                "sha256:4716a9874bd246d68cca2ddd49faa55e9c280bb68fc399d839d902982647784e",
-                "sha256:c18ad980c5f35079935a02d27e4307da6e7b6f5722cabcb88e9128e4c47a36e8"
+                "sha256:178beb22df4927acc7fffb197e586a2a4738c040d42b64bd76071f21e4bad544",
+                "sha256:555577563aa3f46da096f9643c5a55dc8a8c9bb70971aa43e46d196794606f6f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.4.0"
+            "version": "==2.0.0"
         },
         "invenio-cache": {
             "hashes": [
-                "sha256:6c53c84c71390daa7348d81cd98217a22437279330049cbfb44d633b54f6b2a5",
-                "sha256:df11bbd387c11450952c7ba059353a9ceb8a678cdddeaba6eae8dc6fab8c1ffb"
+                "sha256:ef493a844d05be20c4ec6de62ce3fdf55a2c8781fdc2015cdf1f9f9cf69c3780",
+                "sha256:f957f2c16a976b182ecec243ad51e0e43fde52155e31575a0ae867b47cadfa7d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.3.1"
+            "version": "==2.0.0"
         },
         "invenio-celery": {
             "hashes": [
-                "sha256:3698d61fcca5f3fc2f643939df85084bb5849b4af0a54415c7f6eecfd8b9f14c",
-                "sha256:f8ead8ea0c94fc0fc7cc905e4280c46e57a44d1cf0e299a06e01f12952772466"
+                "sha256:69092dcdaf2467e8b5c012a1a3e2d98b5e14a540d62634ea2cfdfefce5dc61a1",
+                "sha256:ab361212ab7ab5514deb2ffe3b2305ac2b942e2c16f333bf6dbc18f1d9da38f8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.3.2"
+            "version": "==2.0.0"
         },
         "invenio-communities": {
             "hashes": [
-                "sha256:88529a885a047a9070ee2961db6bd2f04423728088e6b13bfe9c9f23e5a7d5a5",
-                "sha256:bce6df9d2b0a055cc6158cea8400b64d4423da5bac8ddfba1bb45a11beac963a"
+                "sha256:20f550ce15d1c9ca6409eec0124307231d828daa294ead60ff9a53e253d027c0",
+                "sha256:33aac9a5cf6128de777ba33b73f5cbdfd635fc114dc2ec066291489a3e8764a4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==17.8.1"
+            "version": "==17.7.1"
         },
         "invenio-config": {
             "hashes": [
@@ -1075,88 +1077,84 @@
             "version": "==1.0.4"
         },
         "invenio-db": {
-            "extras": [
-                "mysql",
-                "postgresql"
-            ],
             "hashes": [
-                "sha256:275307e6a6980140f05ce765f54e0efc5f91a09cf206bdeecea874251f3aafbb",
-                "sha256:9f07739b8854185b594ea7917dfb8443ffb309981c60d2f660da3e2c12fe7a2d"
+                "sha256:3f2dc12d95fc2febcc2b35cb3b4ec315dd9b3ec43b272a8028b8ba76a4167be3",
+                "sha256:d365af39517b5effae56dd311879f79217bee8a6fc9c92e399b7fb6aee7f4ad6"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.3.1"
+            "version": "==2.0.0"
         },
         "invenio-drafts-resources": {
             "hashes": [
-                "sha256:190a6d417bb9f00635742cb3bc690d3559be451f550db069d0440d7fc754dc2c",
-                "sha256:81b46b71a842200f4ca034111b9b3be82bc396d898c31e5c1d9971496c7329e5"
+                "sha256:37106b76644d669e31e250e4f54372b911d1caf5fdf212fc620e640f59ae63b4",
+                "sha256:c9d52305c11f5001bc166c78c549bf7aada79519e53541fa7d79d4d38606c74d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.1.0"
+            "version": "==6.0.0"
         },
         "invenio-files-rest": {
             "hashes": [
-                "sha256:3d0e6d464e1f51e55ad08f5ac42d969c40cfbd73c02852b9537a55e6541a63d1",
-                "sha256:59569863adc1bf8a21a0205e9fa4ad9633808edcf6d13226557baa3e5bea0188"
+                "sha256:b8f1dc11048d1a0fb309568c993d62af307ce73d0f78fc6a729a64976c39f575",
+                "sha256:d10cb000c36df7da4330fba99fd45f356d9a0bb34146ba81570e7ca4a3489ccc"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.2.4"
+            "version": "==3.0.0"
         },
         "invenio-formatter": {
             "hashes": [
-                "sha256:7aee94ec01c3cabc6da57825df3352a12f8b91a2e69c7599bdf001febf6bed05",
-                "sha256:9323dea423927829a332cee7ae1d4c0d127a51709cec612f17da8d5cb1a7f711"
+                "sha256:4d24b4a5474221bed7e3b8c152d8215cdb0ab22ffbd4c0ba37d40da39bb98620",
+                "sha256:872ba76494e2e66483c8c1e0838f8c51c75404e94af0d09e7b329e391f14c21b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.0.4"
+            "version": "==3.0.0"
         },
         "invenio-github": {
             "hashes": [
-                "sha256:91446729f8c23815ddb50b26601a4ccd4faba9635eef401d09b26847400df5ef",
-                "sha256:d4fe85985e44cce999fa433662962d841b2a26a782073973f9be7b48694e70b6"
+                "sha256:59db1d1896b9a8c34834bd8215f144a0bc0e7306b5465c4af155e35335ae9b96",
+                "sha256:9d24b523c90f5ab136bc78a15687edff8a3440cbdfe3ad90457d07411dd08bd8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.5.4"
+            "version": "==2.0.0"
         },
         "invenio-i18n": {
             "hashes": [
-                "sha256:57ccb74ab41061d7930e708ff812d76b03d496d37b17d1833421e175f30748db",
-                "sha256:61651313bd0a8c0d5f8b6dc59fe45c52e8c0bb01f0f9488fd23159e27fd89ad9"
+                "sha256:81d55f1e96a8c1f9c777565d31af5fbd5c6cc5adebc1adb93f5ad2faa3e1bb2f",
+                "sha256:d06e02c14e07a09bf6989ac564c8cc17388382ebd2806c2fc18e8495421b767b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.2.0"
+            "version": "==3.0.0"
         },
         "invenio-indexer": {
             "hashes": [
-                "sha256:99d6a7edb63025cc439d87cf18789c89321e23ca8e34aae9775243e9a6402d79",
-                "sha256:f11c752d7b3cffe4db6a659106e48316963b4771505e0a72375339eea1be7ba0"
+                "sha256:4c1f1655160573c8abc6a63671d352b89c9ddcc0e8f198976f705f7345c4f37a",
+                "sha256:6ca6890c11c9143a8329787a6fa0e51a66233db92585774d8e427000a71ea44c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.4.0"
+            "version": "==3.0.0"
         },
         "invenio-jobs": {
             "hashes": [
-                "sha256:23f7d1ad91dab98e52fd0cc0ef759c9cff6b8cf994eff677d42b06d6799cdb0c",
-                "sha256:31d858a9f091d44c904bb11055983a3cb9496982d1ef5473da60b13468808d49"
+                "sha256:7dcb9bb4f8a4b3a7f9f2c5f507000e63a967203cd3b24e46a96cca97f08ebf0b",
+                "sha256:ef091392205231b617e429eb584c4e825d4088fb77616213632efb71e871f796"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.1.1"
+            "version": "==3.0.0.dev1"
         },
         "invenio-jsonschemas": {
             "hashes": [
-                "sha256:0ef364acbfb74d382ae83904f3d5390faa893902f25e88110ff18275ab36863b",
-                "sha256:dedec03de1eb6798ee54d684b0188a9a616f11a508054463e158c473cbcaea07"
+                "sha256:25fe51ff97110ec52c81f50cead599264cc8c0a7ef67f7bb3fa4ffe81e483ffb",
+                "sha256:6b4faf7958e21f7e3aa9a0c9fd93a971965a1ab8b14a13cde64efcdb8d7a9065"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.1.5"
+            "version": "==2.0.0"
         },
         "invenio-logging": {
             "hashes": [
-                "sha256:2bcd75284a52e1a317c2a5aa8de44b14e7852054ffef84f5adf7307e61df781f",
-                "sha256:4a77eccd6d5a8be0d144972ddbb885d725403e89b3915a6ada1b5c51c15922c0"
+                "sha256:401aa84e82d7e180d1be4972f6f70e87aab2e7df7ce16ac477cde6d7a7c1263b",
+                "sha256:98a684469540dffcef93d0612bd9da47e25c33ad61a14c65943e130a2fce3667"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.1.4"
+            "version": "==4.0.2"
         },
         "invenio-mail": {
             "hashes": [
@@ -1168,59 +1166,59 @@
         },
         "invenio-notifications": {
             "hashes": [
-                "sha256:68a6282795284300e00bbf22e9e05e08158ee856c2aef3e7c5022594625d9deb",
-                "sha256:80b0ea60f059634ce58fa51c519d13bd822875a5f285c83f652d2b1a97049f83"
+                "sha256:073aecbfe693fe94167a6db163a61ceb24bdbf5930059be68f3d1c892ea556ea",
+                "sha256:84062a753b04f48dcc0a535ad648c37731a291a7b6ad6b7223fc7b7a4418eb50"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.6.1"
+            "version": "==1.0.0"
         },
         "invenio-oaiserver": {
             "hashes": [
-                "sha256:0315e7042db09fc6599592bd8071def1e48f36a8d2ca9fda44da87fa009992d2",
-                "sha256:818181e6bec9b4169065ed618a3d13fdef88ad37223195714b37288a2151be71"
+                "sha256:5a5f8b35287927142c0590afa6805520bd5672690d9264a38707081c6a038772",
+                "sha256:831a7b131d66516c949e013cd4d28b41c497e6275a805ec72bc6e25a63d2dc40"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.3.0"
+            "version": "==3.1.0"
         },
         "invenio-oauth2server": {
             "hashes": [
-                "sha256:0b18b2c228f6cb8af3925eb9cc7f962ece4ec27e3817378c10a7a77f9c236b58",
-                "sha256:4a8173b3716a0e0fb48655223f3a37738d165c27c1f353e105fe3baf1651c0e9"
+                "sha256:0be042880fd848b884515db88fa084c7c97ec87a7d8ddb489c7d4917741afba8",
+                "sha256:8bfbf3f56bf3908d1ed9d99b90a2336efaf1a61378b37fa2f291043ce1e05837"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.3.1"
+            "version": "==3.0.0"
         },
         "invenio-oauthclient": {
             "hashes": [
-                "sha256:39bf0a33e70ef0305855a4d1832830a6dd489c5e173243a97201584bdf8d8ab9",
-                "sha256:c49bbbf8ffc5ef00f50ea1650639e3dd9b1f8b5717bf0181be149b7c2f66578b"
+                "sha256:7564567db6bd0e1c4cc8d06c9cc6ae286a300bc77184b7545afcde115827d91e",
+                "sha256:c5e0485908113c07b1395ba087b1aba08ed70bc18b6ad1daf16ab7116ffee686"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.1.3"
+            "version": "==5.1.0"
         },
         "invenio-pages": {
             "hashes": [
-                "sha256:3b15fca9e48f8551d2b788d6b2b22c5b1b99b6526d47ecedc89d22ce82b399e0",
-                "sha256:8f24e40699724576c22c406d26bb3cf2f2de7018d570d47ca2af6ef02e7465ec"
+                "sha256:309daf843f89c953440803136c3be27ce0f8490a02bdfc3d1f9f5dbe5b304226",
+                "sha256:7451917b9d686f819565343d1d69ffd6ad47873846dc449c6468f84d9d90d32e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.1.2"
+            "version": "==5.0.0"
         },
         "invenio-pidstore": {
             "hashes": [
-                "sha256:d6f35aacdbe622d2114fdc921f9ae2fe8d3708c4c06a11b5e3f6d768c750b155",
-                "sha256:f0124a293fc62a559052625f189176272ecc2171d0a3d3d9cf81006278699027"
+                "sha256:08c468c7d470672efc89111210ca41930b93cee632aa472c4614318c912e010c",
+                "sha256:cff9b9bd37dd3c3ab1ab4ba9bfb165a1586716253ef6f98a35406aeb03e44a80"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.3.4"
+            "version": "==2.0.0"
         },
         "invenio-previewer": {
             "hashes": [
-                "sha256:0a803fac1b911ec3b080165ed4ac48bf340bfcad3849275ab68870211fe08075",
-                "sha256:cf4510acf7bc93e9329280e7c894fca53a5279a73877437afd25e44e6b89cad1"
+                "sha256:8bbe458cb8780663a0b2ad00b78ec215132d23990d48a1cc25e5bbbb4d1c749a",
+                "sha256:aa8d3b38da6e9ecb4cbe0b42d9f6c209ede6f63a2fdebecc8c43a215e15e0923"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.2.2"
+            "version": "==3.0.0"
         },
         "invenio-queues": {
             "hashes": [
@@ -1232,19 +1230,19 @@
         },
         "invenio-rdm-records": {
             "hashes": [
-                "sha256:7395969ae80c54e4a3df7a5a1751302d0aa05abb37d4d8055b298ea52a43c2d4",
-                "sha256:c8d08705e8a105dd03515f71feb1035ce9ff459997611708f84d3f731ba1e07b"
+                "sha256:a0182ec0f7029bf1fc5428f45acf5cf962bb952170efae5fd65078ee9ac96743",
+                "sha256:a8cde6f107a97a549144afd22bda495afc2c61bd46a867dff3bcde860d0aaf6a"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==16.7.0"
+            "index": "pypi",
+            "version": "==16.4.2"
         },
         "invenio-records": {
             "hashes": [
-                "sha256:253649c67174690a7ac4b1c7bdefdea5647bd73e5b067dfea24dc9f254251047",
-                "sha256:26b6d4c45da343e146c05a13d90db57c6d99d499e8a4c8596fc95fe7e4dbbbf3"
+                "sha256:7bf536e454df106b7e89db98889e0fd6833822346c4fbe352b21f7f64fedc77d",
+                "sha256:b895e9b0189c67f6e3094a56b318199defd5c7d36b65f0571a893113cfdad7f7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.4.1"
+            "version": "==3.0.2"
         },
         "invenio-records-files": {
             "hashes": [
@@ -1255,113 +1253,113 @@
         },
         "invenio-records-permissions": {
             "hashes": [
-                "sha256:3e8cdd3d3b48331aebdc0470d3fc50c340dd4921f74ecc2ed4b16341e7fd70b0",
-                "sha256:723c69e3f3a40028b6e3070053798054c7dac5a4e92597a8cd8602c289cc08af"
+                "sha256:702a568d52aa04b2780d104052af4be325e7922cd205021ed86be97dac83a228",
+                "sha256:e7295fa284a365f72ff81fb96ca13def949801c509cef30d2328820fe167381d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.22.0"
+            "version": "==1.0.0"
         },
         "invenio-records-resources": {
             "hashes": [
-                "sha256:24d0834f0768af45571e7fc563c25676c20733e607a4552391a023d07e1eeef8",
-                "sha256:d148673436382a186da41631afbb2ec436703dd4a1cd7dd9787b4bd7923e53d4"
+                "sha256:aabecaed42c6f432f21f2c8d8fc2c4bee57930ab3423b7b2544fa01d84da38e7",
+                "sha256:fabad4b375a03e433c244bbeab482abab203187f7cef30a841b1c5504e6c4f1d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.5.0"
+            "version": "==7.0.0"
         },
         "invenio-records-rest": {
             "hashes": [
-                "sha256:72fd085ac13e961380c60632d28c01d9b8707c74d7633c7911aefd39cc7e102f",
-                "sha256:a5bb71279127ce1c9751aec3d10331b0546e77f5df4b557b6ec13a14e9b0c332"
+                "sha256:69c09a50f568b5cbf8e6d8bee2360e2725ce415b2c63e2d40aaf28a45e6cec7d",
+                "sha256:c4dbaba0a83e0a732906697851867a5e1d4474925abc949ac3ebc4fac2d0494d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.4.1"
+            "version": "==3.0.0"
         },
         "invenio-records-ui": {
             "hashes": [
-                "sha256:6268690c30ff257a5b1bdb8db33fdead7e6e222b80fb987f3242a47efd869b22",
-                "sha256:6791a0e458352275e0c0ed4d629d4e624b3b4cb93916f6f7bbce1aa6f01794bf"
+                "sha256:74f332598d655ea92a0fc3af6e96819549185dee7eddf7fe0bd578b8f043fabc",
+                "sha256:dc6a35b413820dd6487737eb02110a088a410d2eea6ec5941146109515d58fc1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.2.2"
+            "version": "==2.0.0"
         },
         "invenio-requests": {
             "hashes": [
-                "sha256:2cdebfda3328f9ed7da86df0c6ea10243642ceb77469722a0ce1fb495458f95d",
-                "sha256:e0cfa22257ca84747cb0f9b37f296b096386447c549cd8abdab7051a038a31f7"
+                "sha256:2716f211a58c839c06be29d1770debe3e64ab8ec7cdf74e488e2d3d0ac739c24",
+                "sha256:63fcd56f51df311b4141b62c1efa2a3b3ac7f1b1f10989a1fca9d0e069e79d94"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.5.0"
+            "version": "==6.0.0.dev1"
         },
         "invenio-rest": {
             "hashes": [
-                "sha256:dc57a22dd45a4043e27e2ca2cee44b2ccb337e6c94d5f5aaf17e1571b3e4f69e",
-                "sha256:e338f76aaf56a92cd18df3d54532c26f1c77fbeb44f1197fdd98fcc2c78b92ab"
+                "sha256:4655f4385037b828f2c6784e1e00f148d0a4909b877b5d5b3154a56bd9a1e144",
+                "sha256:8f705f9e7452b82f52383f6de5739da3a361f55db3467391884857b7aa3ed6be"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.5.0"
+            "version": "==2.0.0"
         },
         "invenio-search": {
             "extras": [
                 "opensearch2"
             ],
             "hashes": [
-                "sha256:569df7a0db6b84951acecbd60b5871c9f06aaf61421bf493f9ce646f685eb0a6",
-                "sha256:ced2c342a69b8a27262728b00c51d014eaf32a1330499decac192fa810141d21"
+                "sha256:53b7db0d7c851dd30c6dcbddf649feffde60bb28ef1d09de26140537b77554af",
+                "sha256:8bcc183ac3b59f23ac2b19e19dcc433fc1663dfa43cb20af6ee2213393c5ab86"
             ],
-            "version": "==2.4.1"
+            "version": "==3.0.0"
         },
         "invenio-search-ui": {
             "hashes": [
-                "sha256:4ab84a506d00a5ddf8c425b5fd792de3e710a5341bf31d71c4af1d9492f68b09",
-                "sha256:4cf8cb3ea2fa8ecf4ee59f71c6acda06f0af0d9e50c6cafead7f2f22610b175c"
+                "sha256:00d0abc7aad5e27c46cc93427098545bef266e779471271f6b64a34d177863e6",
+                "sha256:06448c1f55f54b863eb54a0f431168c4880d982e09639e6ce3d6a52e289372de"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.0.0"
+        },
+        "invenio-stats": {
+            "hashes": [
+                "sha256:295746c334df5bdaab46134165e04b2a05c124b69b84526a324254930591866f",
+                "sha256:bafbe2f49926af043535590aa6ac00417d11a83ae6799f9c9f42fd3a81ac885e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.2.1"
+        },
+        "invenio-swh": {
+            "git": "https://github.com/inveniosoftware/invenio-swh",
+            "ref": "81ed234bf47c85e8babf04ae85ebae145929329f"
+        },
+        "invenio-theme": {
+            "hashes": [
+                "sha256:02a8d902dbf720d6b227467050e848a30751d49cf2669503462afa6e6639ba06",
+                "sha256:e5dea58cd6adc64e3861910e607787e87252baa3d6738706189ceb582a004440"
+            ],
+            "index": "pypi",
+            "version": "==3.5.1"
+        },
+        "invenio-userprofiles": {
+            "hashes": [
+                "sha256:20387f0c598e7ed9798df38dc41070df8c7af32452ebbc77016001d92a2cd345",
+                "sha256:5383a20a8a14cf71fe5132f8fb83bfcc91a49d696c563310f6f6c7ff4f8f79b2"
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.0.1"
         },
-        "invenio-stats": {
-            "hashes": [
-                "sha256:b360f4e88fd7f60bf8a43a4f1dfb49ae24b7bedfad5baa631262edb188def3dd",
-                "sha256:fdcfb01ab34eb410022a06412b91bac302fa932c0e12d916acf399dec8ced438"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.3.0"
-        },
-        "invenio-swh": {
-            "git": "https://github.com/inveniosoftware/invenio-swh",
-            "ref": "89dc9a7e6bc4488d3ea5a21e978b4edec2b8697c"
-        },
-        "invenio-theme": {
-            "hashes": [
-                "sha256:7af06ccdb49218245a0a15d625fa8dd51ce1ff0a55c8f813cbe8e5efcecb410e",
-                "sha256:e96719c3c07b222fd4946dd501054be4bf1ff58d2ea99d608ecc5506bd310efb"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.6.1"
-        },
-        "invenio-userprofiles": {
-            "hashes": [
-                "sha256:434539bf0801f9b1253943d5cb44f3c5a8c9bf3138507f7cc5fcfa6b7a807b93",
-                "sha256:e9a8b7c8c17416ce66139704bdca339f559462f48e27dc8bba12ff12022e8188"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.0.2"
-        },
         "invenio-users-resources": {
             "hashes": [
-                "sha256:497f7a41454076faa49d4ca796d323afeebb57db8c0afc44e927d26871ac26fb",
-                "sha256:68425e4a585916daa533385e29d6afbf20e7fdcd2e0d84f333b553417ffe79f5"
+                "sha256:56329d7bf02111e85b3759bf91529761631f4f95437b57f8e593419c3f9b8ccd",
+                "sha256:aaa107ab9ca4019c0b41c57c7e30649f894c0b9d72b0c72c534de3e11c4787b9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.1.3"
+            "version": "==7.0.0.dev1"
         },
         "invenio-vocabularies": {
             "hashes": [
-                "sha256:1d6e97f7b4504026e4fbb7f7748d22c5c8eb4da2d09f3d94f0d193e4f502e8f1",
-                "sha256:9e1c0c295e8b988198fca7441fa8d4dabac60295566d1e11f091abec53d55ea2"
+                "sha256:340015c6accff95811b4bf85461bf7fed5e506338168fbb07cb7423035a82790",
+                "sha256:f96fa5b6eb32a17045b81a5e38960323e1785075e665663ca7bb0be79bd268b2"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==6.11.0"
+            "index": "pypi",
+            "version": "==6.9.0"
         },
         "invenio-webhooks": {
             "hashes": [
@@ -1396,11 +1394,11 @@
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
-                "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"
+                "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef",
+                "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.0"
         },
         "jedi": {
             "hashes": [
@@ -1702,11 +1700,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:ec5d00d873ce473b7f2ffcb7104286a376c354cab0c2fa12f5573dab03e87210",
-                "sha256:f4debda3bb11153d81ac34b0d582bf23053055ee11e791b54b4b35493468040a"
+                "sha256:3a8dfda6edd8dcdbf216c0ede1d1e78d230a6dc9c5a088f58c4083b974a0d468",
+                "sha256:fece2eb2c941180ea1b7fcbd4a83c51bfdd50093fdd3ad2585ee5e1df2508491"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.25.1"
+            "version": "==3.23.1"
         },
         "marshmallow-oneofschema": {
             "hashes": [
@@ -1989,10 +1987,11 @@
         },
         "oauthlib": {
             "hashes": [
-                "sha256:ac35665a61c1685c56336bda97d5eefa246f1202618a1d6f34fccb1bdd404162",
-                "sha256:d883b36b21a6ad813953803edfa563b1b579d79ca758fe950d1bc9e8b326025b"
+                "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca",
+                "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"
             ],
-            "version": "==2.1.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.2.2"
         },
         "opensearch-dsl": {
             "hashes": [
@@ -2369,11 +2368,11 @@
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:202481f716cc8250e4be8fce997781ebf7917701b59652458ee47f2401f818b5",
-                "sha256:741bd7c4ff961ba40b7528d32284c53bc436b8b1645e8e37c3e57770b8700a34"
+                "sha256:49f81412242d3527b8b4967b990df395c89563043bc51a3d2d7d500e52123b77",
+                "sha256:b0ee1e0b2bef1071a47891ab17003bfe5bf824a398e13f49f8ed653b699369a7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.14"
+            "version": "==10.12"
         },
         "pymysql": {
             "hashes": [
@@ -2465,6 +2464,67 @@
                 "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"
             ],
             "version": "==2024.1"
+        },
+        "pyuwsgi": {
+            "hashes": [
+                "sha256:06a0294910de374ff43032b41333f7f9b62d59308b7f3eea29bc64d78fb93613",
+                "sha256:0b1c131288b6b473e39c5b02e63c34b64422665749dcadee41ef98d64b5db5d0",
+                "sha256:1157f49bfb360c1883feec82553adbed1e4a447e5ced66f36525a92f0e46397e",
+                "sha256:1573ac212201ccbfea00b93d88fde89205d3c2f0a4d0c973058aa0b8745d4a2d",
+                "sha256:167d05f635c46287ee8709b09f422fbc16310acad3c9bd100a267679c061fe62",
+                "sha256:1dbe7d0bb8184ef6c9bec1a3593a02bd27de0348807c97533069a7bca2603d19",
+                "sha256:1e6afc8916098ca35119dc0c619f29ef572f72c6f4425f29604c17397ae313b2",
+                "sha256:20d23ddbf28a831543d586c9e5727c9c28d7be7bd7cb853c7db2e0c529f605bf",
+                "sha256:219032fe8bb8306cb05e7bc509ff134c853cfcbd7d809a867d5b8ecd589bef5d",
+                "sha256:2300dba7037089a23b0eb4d2b037391be4d89b73e597671d0f23903a529cd552",
+                "sha256:29c6f658625f2470d905276987aec898a690eee33f49c9c3961ca9d912abd046",
+                "sha256:2c29fdf5baaff9d717aedb63e7b78b90bec561afc099f952db44699adcb0c575",
+                "sha256:30798db4c0c9b36a12fd831cfe621c69569e226d177b3c28c6a191e2a819604f",
+                "sha256:327800fa58bfba5d6f2bd19331e812e0e1250aaa681874f5b92998f68e6bab75",
+                "sha256:32838668eab84ac6847876d9da72768552fca556e09a1fe3a63facb976bd12ad",
+                "sha256:36d9c628067fc1c58534b800aacbb7499813b214cabe9128fb5ba79ad32ff9b9",
+                "sha256:3b85217fd489d623512066ffed0cfc4c95bd3321655e9c6ea13cf6c7f064c9b0",
+                "sha256:44bfebc678b2dde10382197b9199ce546b699a672e05e139a3827efb121e704f",
+                "sha256:4a4fbc27ccbe24cffb65ce89fbb7cf2e8a0af625b7706179786a810688cefd7f",
+                "sha256:4fcf8a76ad40af8c3c1a1e98f11be03e999e4957f48da6a180f5b8fc40b963c4",
+                "sha256:5a90b72a25ba1a34299f4958237a12f18154b373a9a0a93a6267af5e8798c1ee",
+                "sha256:5b6bec34ca5b200dfc8b10c74b0a9e3da051747f5faa300f681bbb46cf573fd0",
+                "sha256:5bdd7ec17f795049ef346dc10efbfce6c1a9500f3f39262c86107c70b9a83cb9",
+                "sha256:5c2caedcc6fd0cd217b65ab863a51e18032b3ce81316d0a079652ed43ed8ba68",
+                "sha256:6105bd14fa2e61505dc116574ba79f3f6e0f425f206d3bec2337463457167aba",
+                "sha256:611e6585a51b3a1f9619e1069dcdc1b8bf37ad7aa16b271fce2ca3e1440fc548",
+                "sha256:64b40503a87621e79efe4306b77595a0cbcb69afa4f3428a85e4e8ac46068d88",
+                "sha256:6c969668db4599b6a5c927ad4bc1d698ea8c57fb10a943b51402fe80a97cdfc9",
+                "sha256:735861b77e607e133f9905a5e0ba6505ef6788df1cfdb6af06e6dfef07dfa9af",
+                "sha256:787fd67086df87921bc8837ef018cd7cf02834136f4735811375c1e17b776b40",
+                "sha256:7e8fd6f2116d2afce52965c940a96a939e9d9c7409f3e19ba445a25e33779f08",
+                "sha256:81e59789af3b568ed1c4484b4bac9e4b79810f4774d8d3ab9056eb3f500e1e94",
+                "sha256:8dc521dd980ee431d4e6fc9a018ad1df4840c4551f281a598878083f3d155243",
+                "sha256:91bdc9fcd1e13088ef57f7e58e427c9539e9d2c6d75157f55b5d17ef599e61ee",
+                "sha256:9390e8a2297186ede814d5863a06fa98b91295c813fdd3d08fe1357793476486",
+                "sha256:941d44a67760dc173c0f8318f8b7bd1ef7927533d6efb4641b2ea9e934f09981",
+                "sha256:9436ac4450730e1bcca4591ebb781eabcfcf93462114e199b951118032144323",
+                "sha256:a1b0a27f1b9c63a1ac9788a068e5905b8ebedb1b460b9256ac85d1318fd6a9a6",
+                "sha256:a8a932c9d34b2f0007eabf04728ffae7be8bfb87a044daee50a82b6796ad5b34",
+                "sha256:a9382286b9cf94b5d826388cda7097235b0f1348c7549c8b71100ecfc8d74c58",
+                "sha256:ad20990917364f8f9b3fc62424edc6d9a992146bc5e15d37b1bbc9c3934ddf9b",
+                "sha256:b2f118d7211e4afb7e8248cd380c1eac3e87604c1143bbccac1679c3a3642e22",
+                "sha256:b351e76c9a18dc3e8a635994a98571b9ca7f10e371a0085ae3c8cd95f3db66cd",
+                "sha256:c0b1b09bdf836a6cacf35e2bb06f6ad4b7dff6c6ad48895e1b1c0b0d19bbbfcc",
+                "sha256:c9feafdfa73a632767a0cb1bafd285e36fba925b9c9ddd2b3311f2963c917c9f",
+                "sha256:cf4f03d8b74d9754efd8cc6b0566258ccc1123a8c2fe49a11835242a6fb27efc",
+                "sha256:dc85ba45af7a7b89e3a722cf9cbba724fabb2c3b5caf3c25d67286ab329df97c",
+                "sha256:e1289847ba14ae2ba4f918c57e9d257ecd82a43f6c7a026e155577596c6304f1",
+                "sha256:e227836984735fdfa26d3be4927a6ae060ad8a0d28ef4a6adcd4f47fbfd7e876",
+                "sha256:e4e4775246f2ab079ea4bcf69d70441ffe81eba82a88eb4da6ae9debf334511f",
+                "sha256:f27ee3445eab37fabbe3afc6af68220c8f0bd28c5228d6a2ec7886d080614ad4",
+                "sha256:f4563fa76d64a2c309eb902511a1fcdce66865a03785c61494db5c53136ffa7a",
+                "sha256:f55071012ce5d728ac428be78c3710e986acc02dcfc1d72f3a76541b85e25cfb",
+                "sha256:f61adc1ab15da41675af36256feccd0cafb797c703499930fd5b3b381b0b6273",
+                "sha256:fa60c4fb1e483c079d1f3767863bc41884f6322f0744ac5d6398b0e505e9d21e"
+            ],
+            "index": "pypi",
+            "version": "==2.0.28.post1"
         },
         "pyvips": {
             "hashes": [
@@ -2789,11 +2849,11 @@
         },
         "requests-oauthlib": {
             "hashes": [
-                "sha256:490229d14a98e1b69612dcc1a22887ec14f5487dc1b8c6d7ba7f77a42ce7347b",
-                "sha256:be76f2bb72ca5525998e81d47913e09b1ca8b7957ae89b46f787a79e68ad5e61",
-                "sha256:eabd8eb700ebed81ba080c6ead96d39d6bdc39996094bd23000204f6965786b0"
+                "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36",
+                "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"
             ],
-            "version": "==1.1.0"
+            "markers": "python_version >= '3.4'",
+            "version": "==2.0.0"
         },
         "rich": {
             "hashes": [
@@ -3055,68 +3115,81 @@
                 "asyncio"
             ],
             "hashes": [
-                "sha256:02d2ecb9508f16ab9c5af466dfe5a88e26adf2e1a8d1c56eb616396ccae2c186",
-                "sha256:0b76bbb1cbae618d10679be8966f6d66c94f301cfc15cb49e2f2382563fb6efb",
-                "sha256:0de620f978ca273ce027769dc8db7e6ee72631796187adc8471b3c76091b809e",
-                "sha256:1183599e25fa38a1a322294b949da02b4f0da13dbc2688ef9dbe746df573f8a6",
-                "sha256:12bc0141b245918b80d9d17eca94663dbd3f5266ac77a0be60750f36102bbb0f",
-                "sha256:1390ca2d301a2708fd4425c6d75528d22f26b8f5cbc9faba1ddca136671432bc",
-                "sha256:13e91d6892b5fcb94a36ba061fb7a1f03d0185ed9d8a77c84ba389e5bb05e936",
-                "sha256:14b3f4783275339170984cadda66e3ec011cce87b405968dc8d51cf0f9997b0d",
-                "sha256:1576fba3616f79496e2f067262200dbf4aab1bb727cd7e4e006076686413c80c",
-                "sha256:1990d5a6a5dc358a0894c8ca02043fb9a5ad9538422001fb2826e91c50f1d539",
-                "sha256:1d83cd1cc03c22d922ec94d0d5f7b7c96b1332f5e122e81b1a61fb22da77879a",
-                "sha256:1e8c1b9ecaf9f2590337d5622189aeb2f0dbc54ba0232fa0856cf390957584a9",
-                "sha256:26e78444bc77d089e62874dc74df05a5c71f01ac598010a327881a48408d0064",
-                "sha256:2b37931eac4b837c45e2522066bda221ac6d80e78922fb77c75eb12e4dbcdee5",
-                "sha256:3112de9e11ff1957148c6de1df2bc5cc1440ee36783412e5eedc6f53638a577d",
-                "sha256:394b0135900b62dbf63e4809cdc8ac923182af2816d06ea61cd6763943c2cc05",
-                "sha256:3f01c2629a7d6b30d8afe0326b8c649b74825a0e1ebdcb01e8ffd1c920deb07d",
-                "sha256:41cffc63c7c83dfc30c4cab5b4308ba74440a9633c4509c51a0c52431fb0f8ab",
-                "sha256:4470fbed088c35dc20b78a39aaf4ae54fe81790c783b3264872a0224f437c31a",
-                "sha256:5ed3576675c187e3baa80b02c4c9d0edfab78eff4e89dd9da736b921333a2432",
-                "sha256:6b24364150738ce488333b3fb48bfa14c189a66de41cd632796fbcacb26b4585",
-                "sha256:6da60fb24577f989535b8fc8b2ddc4212204aaf02e53c4c7ac94ac364150ed08",
-                "sha256:76c2ba7b5a09863d0a8166fbc753af96d561818c572dbaf697c52095938e7be4",
-                "sha256:954816850777ac234a4e32b8c88ac1f7847088a6e90cfb8f0e127a1bf3feddff",
-                "sha256:9c24dd161c06992ed16c5e528a75878edbaeced5660c3db88c820f1f0d3fe1f4",
-                "sha256:a01bc25eb7a5688656c8770f931d5cb4a44c7de1b3cec69b84cc9745d1e4cc10",
-                "sha256:a19f816f4702d7b1951d7576026c7124b9bfb64a9543e571774cf517b7a50b29",
-                "sha256:a41611835010ed4ea4c7aed1da5b58aac78ee7e70932a91ed2705a7b38e40f52",
-                "sha256:a49730afb716f3f675755afec109895cab95bc9875db7ffe2e42c1b1c6279482",
-                "sha256:a86b0e4be775902a5496af4fb1b60d8a2a457d78f531458d294360b8637bb014",
-                "sha256:a8a72259a1652f192c68377be7011eac3c463e9892ef2948828c7d58e4829988",
-                "sha256:af00236fe21c4d4f4c227b6ccc19b44c594160cc3ff28d104cdce85855369277",
-                "sha256:b05e0626ec1c391432eabb47a8abd3bf199fb74bfde7cc44a26d2b1b352c2c6e",
-                "sha256:b5933c45d11cbd9694b1540aa9076816cc7406964c7b16a380fd84d3a5fe3241",
-                "sha256:b5e0d47d619c739bdc636bbe007da4519fc953393304a5943e0b5aec96c9877c",
-                "sha256:b67589f7955924865344e6eacfdcf70675e64f36800a576aa5e961f0008cde2a",
-                "sha256:c5a2530400a6e7e68fd1552a55515de6a4559122e495f73554a51cedafc11669",
-                "sha256:cafe0ba3a96d0845121433cffa2b9232844a2609fce694fcc02f3f31214ece28",
-                "sha256:cdb2886c0be2c6c54d0651d5a61c29ef347e8eec81fd83afebbf7b59b80b7393",
-                "sha256:d0cf7076c8578b3de4e43a046cc7a1af8466e1c3f5e64167189fe8958a4f9c02",
-                "sha256:f1e1b92ee4ee9ffc68624ace218b89ca5ca667607ccee4541a90cc44999b9aea",
-                "sha256:f941aaf15f47f316123e1933f9ea91a6efda73a161a6ab6046d1cde37be62c88",
-                "sha256:fb59a11689ff3c58e7652260127f9e34f7f45478a2f3ef831ab6db7bcd72108f",
-                "sha256:fc9ffd9a38e21fad3e8c5a88926d57f94a32546e937e0be46142b2702003eba7"
+                "sha256:03e08af7a5f9386a43919eda9de33ffda16b44eb11f3b313e6822243770e9763",
+                "sha256:0572f4bd6f94752167adfd7c1bed84f4b240ee6203a95e05d1e208d488d0d436",
+                "sha256:07b441f7d03b9a66299ce7ccf3ef2900abc81c0db434f42a5694a37bd73870f2",
+                "sha256:1bc330d9d29c7f06f003ab10e1eaced295e87940405afe1b110f2eb93a233588",
+                "sha256:1e0d612a17581b6616ff03c8e3d5eff7452f34655c901f75d62bd86449d9750e",
+                "sha256:23623166bfefe1487d81b698c423f8678e80df8b54614c2bf4b4cfcd7c711959",
+                "sha256:2519f3a5d0517fc159afab1015e54bb81b4406c278749779be57a569d8d1bb0d",
+                "sha256:28120ef39c92c2dd60f2721af9328479516844c6b550b077ca450c7d7dc68575",
+                "sha256:37350015056a553e442ff672c2d20e6f4b6d0b2495691fa239d8aa18bb3bc908",
+                "sha256:39769a115f730d683b0eb7b694db9789267bcd027326cccc3125e862eb03bfd8",
+                "sha256:3c01117dd36800f2ecaa238c65365b7b16497adc1522bf84906e5710ee9ba0e8",
+                "sha256:3d6718667da04294d7df1670d70eeddd414f313738d20a6f1d1f379e3139a545",
+                "sha256:3dbb986bad3ed5ceaf090200eba750b5245150bd97d3e67343a3cfed06feecf7",
+                "sha256:4557e1f11c5f653ebfdd924f3f9d5ebfc718283b0b9beebaa5dd6b77ec290971",
+                "sha256:46331b00096a6db1fdc052d55b101dbbfc99155a548e20a0e4a8e5e4d1362855",
+                "sha256:4a121d62ebe7d26fec9155f83f8be5189ef1405f5973ea4874a26fab9f1e262c",
+                "sha256:4f5e9cd989b45b73bd359f693b935364f7e1f79486e29015813c338450aa5a71",
+                "sha256:50aae840ebbd6cdd41af1c14590e5741665e5272d2fee999306673a1bb1fdb4d",
+                "sha256:59b1ee96617135f6e1d6f275bbe988f419c5178016f3d41d3c0abb0c819f75bb",
+                "sha256:59b8f3adb3971929a3e660337f5dacc5942c2cdb760afcabb2614ffbda9f9f72",
+                "sha256:66bffbad8d6271bb1cc2f9a4ea4f86f80fe5e2e3e501a5ae2a3dc6a76e604e6f",
+                "sha256:69f93723edbca7342624d09f6704e7126b152eaed3cdbb634cb657a54332a3c5",
+                "sha256:6a440293d802d3011028e14e4226da1434b373cbaf4a4bbb63f845761a708346",
+                "sha256:72c28b84b174ce8af8504ca28ae9347d317f9dba3999e5981a3cd441f3712e24",
+                "sha256:79d2e78abc26d871875b419e1fd3c0bca31a1cb0043277d0d850014599626c2e",
+                "sha256:7f2767680b6d2398aea7082e45a774b2b0767b5c8d8ffb9c8b683088ea9b29c5",
+                "sha256:8318f4776c85abc3f40ab185e388bee7a6ea99e7fa3a30686580b209eaa35c08",
+                "sha256:8958b10490125124463095bbdadda5aa22ec799f91958e410438ad6c97a7b793",
+                "sha256:8c78ac40bde930c60e0f78b3cd184c580f89456dd87fc08f9e3ee3ce8765ce88",
+                "sha256:90812a8933df713fdf748b355527e3af257a11e415b613dd794512461eb8a686",
+                "sha256:9bc633f4ee4b4c46e7adcb3a9b5ec083bf1d9a97c1d3854b92749d935de40b9b",
+                "sha256:9e46ed38affdfc95d2c958de328d037d87801cfcbea6d421000859e9789e61c2",
+                "sha256:9fe53b404f24789b5ea9003fc25b9a3988feddebd7e7b369c8fac27ad6f52f28",
+                "sha256:a4e46a888b54be23d03a89be510f24a7652fe6ff660787b96cd0e57a4ebcb46d",
+                "sha256:a86bfab2ef46d63300c0f06936bd6e6c0105faa11d509083ba8f2f9d237fb5b5",
+                "sha256:ac9dfa18ff2a67b09b372d5db8743c27966abf0e5344c555d86cc7199f7ad83a",
+                "sha256:af148a33ff0349f53512a049c6406923e4e02bf2f26c5fb285f143faf4f0e46a",
+                "sha256:b11d0cfdd2b095e7b0686cf5fabeb9c67fae5b06d265d8180715b8cfa86522e3",
+                "sha256:b2985c0b06e989c043f1dc09d4fe89e1616aadd35392aea2844f0458a989eacf",
+                "sha256:b544ad1935a8541d177cb402948b94e871067656b3a0b9e91dbec136b06a2ff5",
+                "sha256:b5cc79df7f4bc3d11e4b542596c03826063092611e481fcf1c9dfee3c94355ef",
+                "sha256:b817d41d692bf286abc181f8af476c4fbef3fd05e798777492618378448ee689",
+                "sha256:b81ee3d84803fd42d0b154cb6892ae57ea6b7c55d8359a02379965706c7efe6c",
+                "sha256:be9812b766cad94a25bc63bec11f88c4ad3629a0cec1cd5d4ba48dc23860486b",
+                "sha256:c245b1fbade9c35e5bd3b64270ab49ce990369018289ecfde3f9c318411aaa07",
+                "sha256:c3f3631693003d8e585d4200730616b78fafd5a01ef8b698f6967da5c605b3fa",
+                "sha256:c4ae3005ed83f5967f961fd091f2f8c5329161f69ce8480aa8168b2d7fe37f06",
+                "sha256:c54a1e53a0c308a8e8a7dffb59097bff7facda27c70c286f005327f21b2bd6b1",
+                "sha256:d0ddd9db6e59c44875211bc4c7953a9f6638b937b0a88ae6d09eb46cced54eff",
+                "sha256:dc022184d3e5cacc9579e41805a681187650e170eb2fd70e28b86192a479dcaa",
+                "sha256:e32092c47011d113dc01ab3e1d3ce9f006a47223b18422c5c0d150af13a00687",
+                "sha256:f7b64e6ec3f02c35647be6b4851008b26cff592a95ecb13b6788a54ef80bbdd4",
+                "sha256:f942a799516184c855e1a32fbc7b29d7e571b52612647866d4ec1c3242578fcb",
+                "sha256:f9511d8dd4a6e9271d07d150fb2f81874a3c8c95e11ff9af3a2dfc35fe42ee44",
+                "sha256:fd3a55deef00f689ce931d4d1b23fa9f04c880a48ee97af488fd215cf24e2a6c",
+                "sha256:fddbe92b4760c6f5d48162aef14824add991aeda8ddadb3c31d56eb15ca69f8e",
+                "sha256:fdf3386a801ea5aba17c6410dd1dc8d39cf454ca2565541b5ac42a84e1e28f53"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.4.54"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.36"
         },
         "sqlalchemy-continuum": {
             "hashes": [
-                "sha256:e01646cdfbfd6b31a21b0aeba6bbff661258d5be8477c7500cab3a1c74848e6e",
-                "sha256:f884ab36b1be724ecba867f21557f8f4658c1fb9dee6df8fe9a39b63d485bdd5"
+                "sha256:0fd2be79f718eda47c2206879d92ec4ebf1889364637b3caf3ee5d34bd19c8e3",
+                "sha256:154588d79deb8b1683b5f39c130e6f0ad793c0b2f27e8c210565c23fb6fe74de"
             ],
-            "version": "==1.4.1"
+            "version": "==1.4.2"
         },
         "sqlalchemy-utils": {
             "hashes": [
-                "sha256:5c13b5d08adfaa85f3d4e8ec09a75136216fad41346980d02974a70a77988bf9",
-                "sha256:9f9afba607a40455cf703adfa9846584bf26168a0c5a60a70063b70d65051f4d"
+                "sha256:85cf3842da2bf060760f955f8467b87983fb2e30f1764fd0e24a48307dc8ec6e",
+                "sha256:bc599c8c3b3319e53ce6c5c3c471120bd325d0071fb6f38a10e924e3d07b9990"
             ],
-            "markers": "python_version ~= '3.6'",
-            "version": "==0.38.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.41.2"
         },
         "sqlparse": {
             "hashes": [
@@ -3275,11 +3348,11 @@
         },
         "types-pyyaml": {
             "hashes": [
-                "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c",
-                "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6"
+                "sha256:392b267f1c0fe6022952462bf5d6523f31e37f6cea49b14cee7ad634b6301570",
+                "sha256:d1405a86f9576682234ef83bcb4e6fff7c9305c8b1fbad5e0bcd4f7dbdc9c587"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==6.0.12.20241230"
+            "version": "==6.0.12.20240917"
         },
         "types-requests": {
             "hashes": [
@@ -3366,13 +3439,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==1.26.20"
         },
-        "uwsgi": {
-            "hashes": [
-                "sha256:79ca1891ef2df14508ab0471ee8c0eb94bd2d51d03f32f90c4bbe557ab1e99d0"
-            ],
-            "index": "pypi",
-            "version": "==2.0.28"
-        },
         "uwsgi-tools": {
             "hashes": [
                 "sha256:565e10945c50ed6f4378168a2a609bb7d1c2c5b21ab23edd1ad5f73d15ab6356",
@@ -3413,37 +3479,39 @@
         },
         "watchdog": {
             "hashes": [
-                "sha256:102a60093090fc3ff76c983367b19849b7cc24ec414a43c0333680106e62aae1",
-                "sha256:17f1708f7410af92ddf591e94ae71a27a13974559e72f7e9fde3ec174b26ba2e",
-                "sha256:195ab1d9d611a4c1e5311cbf42273bc541e18ea8c32712f2fb703cfc6ff006f9",
-                "sha256:4cb5ecc332112017fbdb19ede78d92e29a8165c46b68a0b8ccbd0a154f196d5e",
-                "sha256:5100eae58133355d3ca6c1083a33b81355c4f452afa474c2633bd2fbbba398b3",
-                "sha256:61fdb8e9c57baf625e27e1420e7ca17f7d2023929cd0065eb79c83da1dfbeacd",
-                "sha256:6ccd8d84b9490a82b51b230740468116b8205822ea5fdc700a553d92661253a3",
-                "sha256:6e01d699cd260d59b84da6bda019dce0a3353e3fcc774408ae767fe88ee096b7",
-                "sha256:748ca797ff59962e83cc8e4b233f87113f3cf247c23e6be58b8a2885c7337aa3",
-                "sha256:83a7cead445008e880dbde833cb9e5cc7b9a0958edb697a96b936621975f15b9",
-                "sha256:8586d98c494690482c963ffb24c49bf9c8c2fe0589cec4dc2f753b78d1ec301d",
-                "sha256:8b5cde14e5c72b2df5d074774bdff69e9b55da77e102a91f36ef26ca35f9819c",
-                "sha256:8c28c23972ec9c524967895ccb1954bc6f6d4a557d36e681a36e84368660c4ce",
-                "sha256:967636031fa4c4955f0f3f22da3c5c418aa65d50908d31b73b3b3ffd66d60640",
-                "sha256:96cbeb494e6cbe3ae6aacc430e678ce4b4dd3ae5125035f72b6eb4e5e9eb4f4e",
-                "sha256:978a1aed55de0b807913b7482d09943b23a2d634040b112bdf31811a422f6344",
-                "sha256:a09483249d25cbdb4c268e020cb861c51baab2d1affd9a6affc68ffe6a231260",
-                "sha256:a480d122740debf0afac4ddd583c6c0bb519c24f817b42ed6f850e2f6f9d64a8",
-                "sha256:adaf2ece15f3afa33a6b45f76b333a7da9256e1360003032524d61bdb4c422ae",
-                "sha256:bc43c1b24d2f86b6e1cc15f68635a959388219426109233e606517ff7d0a5a73",
-                "sha256:c27d8c1535fd4474e40a4b5e01f4ba6720bac58e6751c667895cbc5c8a7af33c",
-                "sha256:cdcc23c9528601a8a293eb4369cbd14f6b4f34f07ae8769421252e9c22718b6f",
-                "sha256:cece1aa596027ff56369f0b50a9de209920e1df9ac6d02c7f9e5d8162eb4f02b",
-                "sha256:d0f29fd9f3f149a5277929de33b4f121a04cf84bb494634707cfa8ea8ae106a8",
-                "sha256:d6b87477752bd86ac5392ecb9eeed92b416898c30bd40c7e2dd03c3146105646",
-                "sha256:e038be858425c4f621900b8ff1a3a1330d9edcfeaa1c0468aeb7e330fb87693e",
-                "sha256:e618a4863726bc7a3c64f95c218437f3349fb9d909eb9ea3a1ed3b567417c661",
-                "sha256:f8ac23ff2c2df4471a61af6490f847633024e5aa120567e08d07af5718c9d092"
+                "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a",
+                "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2",
+                "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f",
+                "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c",
+                "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c",
+                "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c",
+                "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0",
+                "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13",
+                "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134",
+                "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa",
+                "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e",
+                "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379",
+                "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a",
+                "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11",
+                "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282",
+                "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b",
+                "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f",
+                "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c",
+                "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112",
+                "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948",
+                "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881",
+                "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860",
+                "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3",
+                "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680",
+                "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26",
+                "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26",
+                "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e",
+                "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8",
+                "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c",
+                "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==6.0.0"
         },
         "wcwidth": {
             "hashes": [
@@ -3469,11 +3537,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe",
-                "sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612"
+                "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e",
+                "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.2.3"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.3"
         },
         "wrapt": {
             "hashes": [
@@ -3562,24 +3630,26 @@
         },
         "wtforms": {
             "hashes": [
-                "sha256:7b504fc724d0d1d4d5d5c114e778ec88c37ea53144683e084215eed5155ada4c",
-                "sha256:81195de0ac94fbc8368abbaf9197b88c4f3ffd6c2719b5bf5fc9da744f3d829c"
+                "sha256:583bad77ba1dd7286463f21e11aa3043ca4869d03575921d1a1698d0715e0fd4",
+                "sha256:df3e6b70f3192e92623128123ec8dca3067df9cfadd43d59681e210cfb8d4682"
             ],
-            "index": "pypi",
-            "version": "==2.3.3"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.2.1"
         },
         "wtforms-alchemy": {
             "hashes": [
-                "sha256:7748494056bdd96a7566186b8f422180465c337b2e892ad8e82a063cd6c76ca7",
-                "sha256:c14cec7f76e27351a5777182ff39fcba64b7c46a561401835426605e6c83f216"
+                "sha256:561beb2e6e4982f1c95c62e06aef01d6c7ed4e7bfacc42a5d99d43ebe2f4e60f",
+                "sha256:98412e8c50aa21065a4806027252fe73b8b97637a229d5b0431f759d023c5434"
             ],
-            "version": "==0.18.0"
+            "version": "==0.19.0"
         },
         "wtforms-components": {
             "hashes": [
-                "sha256:7d0d83dec6d5352c661e522be628f49c2de3aa78cd79c9caf0c1cc3bff4e3872"
+                "sha256:605762c32588a915b6411628d082799c6c741134fb961244a9bd8ed1686aef74",
+                "sha256:ca94d60a6362c0e4b49d3d09d1eb1ddf5b26c99105a57397af313655f4447f7a"
             ],
-            "version": "==0.10.5"
+            "markers": "python_version >= '3.9'",
+            "version": "==0.11.0"
         },
         "xmltodict": {
             "hashes": [
@@ -3890,11 +3960,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf",
-                "sha256:edee9b0a7ff26621bd5a8c10ff484ae28737a2410d99b0bb9a6850c7fb977aa0"
+                "sha256:5f873c5184c897c8d9d1b05df1e3d01b14910ce69607a117bd3277098a5836ac",
+                "sha256:d667207822eb83f1c4b50949b1623c8fc8d51f2341d65f72e1a1815397551136"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.2.5"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.0"
         },
         "idna": {
             "hashes": [
@@ -3946,11 +4016,11 @@
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
-                "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"
+                "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef",
+                "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.0"
         },
         "jinja2": {
             "hashes": [
@@ -4327,11 +4397,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe",
-                "sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612"
+                "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e",
+                "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.2.3"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.3"
         },
         "zipp": {
             "hashes": [

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -74,7 +74,10 @@ from zenodo_rdm.github.schemas import CitationMetadataSchema
 from zenodo_rdm.legacy.resources import record_serializers
 from zenodo_rdm.metrics.config import METRICS_CACHE_UPDATE_INTERVAL
 from zenodo_rdm.moderation.errors import UserBlockedException
-from zenodo_rdm.moderation.handlers import CommunityModerationHandler, RecordModerationHandler
+from zenodo_rdm.moderation.handlers import (
+    CommunityModerationHandler,
+    RecordModerationHandler,
+)
 from zenodo_rdm.openaire.records.components import OpenAIREComponent
 from zenodo_rdm.permissions import (
     ZenodoCommunityPermissionPolicy,
@@ -82,9 +85,9 @@ from zenodo_rdm.permissions import (
 )
 from zenodo_rdm.queryparser import word_communities, word_doi
 from zenodo_rdm.subcommunities import (
+    ZenodoSubCommunityInvitationRequest,
     ZenodoSubCommunityRequest,
     ZenodoSubcommunityRequestSchema,
-    ZenodoSubCommunityInvitationRequest
 )
 from zenodo_rdm.tokens import RATSubjectSchema
 from zenodo_rdm.views import frontpage_view_function
@@ -103,7 +106,7 @@ SECRET_KEY = "CHANGE_ME"
 # provided, the allowed hosts variable is set to localhost. In production it
 # should be set to the correct host and it is strongly recommended to only
 # route correct hosts to the application.
-APP_ALLOWED_HOSTS = ["0.0.0.0", "localhost", "127.0.0.1"]
+TRUSTED_HOSTS = ["0.0.0.0", "localhost", "127.0.0.1"]
 
 APP_RDM_ROUTES["index"] = ("/", frontpage_view_function)
 
@@ -1086,13 +1089,13 @@ JOBS_ADMINISTRATION_ENABLED = True
 from invenio_app_rdm.config import APP_RDM_RECORD_EXPORTERS as default_exporters
 
 APP_RDM_RECORD_EXPORTERS = {
-    **default_exporters, 
+    **default_exporters,
     "bibtex": {
         "name": _("BibTeX"),
         "serializer": ("zenodo_rdm.serializers:ZenodoBibtexSerializer"),
         "params": {},
         "content-type": "application/x-bibtex",
-        "filename": "{id}.bib"
+        "filename": "{id}.bib",
     },
     "codemeta": {
         "name": _("Codemeta"),
@@ -1103,28 +1106,23 @@ APP_RDM_RECORD_EXPORTERS = {
     },
     "datacite-json": {
         "name": _("DataCite JSON"),
-        "serializer": (
-            "zenodo_rdm.serializers:ZenodoDataciteJSONSerializer"
-        ),
+        "serializer": ("zenodo_rdm.serializers:ZenodoDataciteJSONSerializer"),
         "params": {"options": {"indent": 2, "sort_keys": True}},
         "content-type": "application/vnd.datacite.datacite+json",
         "filename": "{id}.json",
     },
     "datacite-xml": {
         "name": _("DataCite XML"),
-        "serializer": (
-            "zenodo_rdm.serializers:ZenodoDataciteXMLSerializer"
-        ),
+        "serializer": ("zenodo_rdm.serializers:ZenodoDataciteXMLSerializer"),
         "params": {},
         "content-type": "application/vnd.datacite.datacite+xml",
         "filename": "{id}.xml",
     },
-     "cff": {
+    "cff": {
         "name": _("Citation File Format"),
         "serializer": "zenodo_rdm.serializers:ZenodoCFFSerializer",
         "params": {},
         "content-type": "application/x-yaml",
         "filename": "{id}.yaml",
     },
-    
 }

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -879,7 +879,7 @@ ZENODO_EOS_OFFLOAD_X509_KEY_PATH = ""
 
 # TODO: Remove once https://github.com/inveniosoftware/invenio-rdm-records/pull/1789 is merged
 FILES_REST_DEFAULT_QUOTA_SIZE = 5 * 10**10
-FILES_REST_DEFAULT_MAX_FILE_SIZE = 5 * 10**10
+FILES_REST_DEFAULT_MAX_FILE_SIZE = 1 * 10**12  # 1TB (also controls max allowed upload size)
 
 RDM_FILES_DEFAULT_QUOTA_SIZE = 50 * 10**9  # 50GB
 RDM_FILES_DEFAULT_MAX_FILE_SIZE = 50 * 10**9  # 50GB

--- a/site/zenodo_rdm/files.py
+++ b/site/zenodo_rdm/files.py
@@ -117,19 +117,17 @@ class EOSFilesOffload(BaseFileStorage):
             # Content-Type sniffing.
             # (from invenio-files-rest)
             if as_attachment or mimetype == "application/octet-stream":
-                # See https://github.com/pallets/flask/commit/0049922f2e690a6d
+                # see https://github.com/pallets/werkzeug/blob/main/src/werkzeug/utils.py#L456-L465
                 try:
-                    filenames = {"filename": filename.encode("latin-1")}
+                    filename.encode("ascii")
                 except UnicodeEncodeError:
+                    simple = unicodedata.normalize("NFKD", filename)
+                    simple = simple.encode("ascii", "ignore").decode("ascii")
                     # safe = RFC 5987 attr-char
                     quoted = quote(filename, safe="!#$&+-.^_`|~")
-
-                    filenames = {"filename*": "UTF-8''%s" % quoted}
-                    encoded_filename = unicodedata.normalize("NFKD", filename).encode(
-                        "latin-1", "ignore"
-                    )
-                    if encoded_filename:
-                        filenames["filename"] = encoded_filename
+                    filenames = {"filename": simple, "filename*": f"UTF-8''{quoted}"}
+                else:
+                    filenames = {"filename": filename}
                 response.headers.set("Content-Disposition", "attachment", **filenames)
             else:
                 response.headers.set("Content-Disposition", "inline")

--- a/site/zenodo_rdm/legacy/tokens.py
+++ b/site/zenodo_rdm/legacy/tokens.py
@@ -15,9 +15,13 @@ from datetime import datetime
 from functools import partial
 
 from flask import current_app, flash, request, session
+from invenio_base.jws import (
+    BadData,
+    JSONWebSignatureSerializer,
+    SignatureExpired,
+    TimedJSONWebSignatureSerializer,
+)
 from invenio_i18n import _
-from itsdangerous import BadData, SignatureExpired
-from itsdangerous.jws import JSONWebSignatureSerializer, TimedJSONWebSignatureSerializer
 
 _Need = namedtuple("Need", ["method", "value"])
 LegacySecretLinkNeed = partial(_Need, "legacy_secret_link")


### PR DESCRIPTION
- **global: fix Flask v3 deprecations**
  - Uses the new `TRUSTED_HOSTS` config.
  - Replaces JWT imports from itsdangerous to invenio_base.
- **config: bump maximum allowed upload size to 1TB**
- **files: fix filename encoding issues for downloads**
  * See relevant fix applied in invenio-files-rest at https://github.com/inveniosoftware/invenio-files-rest/commit/a419808c16617125590381b7dc02f41ca49359b2

- installation: bump dependencies for Flask v3 and SLQAlchemy v2 support

📁 invenio-access (3.0.2 -> 4.0.0 ⚠️)

    release: v4.0.0
    setup: bump major dependencies

📁 invenio-accounts (5.1.7 -> 6.0.0 ⚠️)

    release: v6.0.0
    fix: cookie_app and users not using same app

    * the problem is since cookie_app and users use different app one closes
      the connection to the database first which is bad
    fix: add translation flag for publishing
    setup: bump major dependencies

📁 invenio-administration (2.9.0 -> 3.1.0 ⚠️)

    release: v3.1.0
    modal: add support for custom modal SUI props
    release: v3.0.0
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-app (1.5.1 -> 2.0.0 ⚠️)

    release: v2.0.0
    factory: change to new TRUSTS_HOSTS from flask
    * flask>=3.1.0 introduced a new configuration variable TRUSTS_HOSTS.
      this removes the necessity to use APP_ALLOWED_HOSTS and the code around it.
    setup: bump major dependencies

📁 invenio-app-rdm (13.0.0b1.dev28 -> 13.0.0b2.dev2 ⚠️)

    📦 release: v13.0.0b2.dev2
    installation: bump dev deps to stable
    📦 release: v13.0.0b2.dev1
    installation: bump communities and rdm-records
    release: v13.0.0b2.dev0
    setup: remove flask pin
    setup: change to reusable workflows
    setup: bump major dependencies
    ui: fix css
    resultList: Add overridable descriptio
    resultView: fix truncateed description
    release: v13.0.0b1.dev30
    administration: compare record revisions

📁 invenio-assets (3.1.0 -> 4.0.0 ⚠️)

    release: v4.0.0
    setup: bump invenio dependencies

📁 invenio-banners (3.2.0 -> 4.1.0 ⚠️)

    release: v4.1.0
    templates: pass ui classes through macro parameters
    release: v4.0.0
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-base (1.4.0 -> 2.0.0 ⚠️)

    release: v2.0.0
    setup: set flask,werkzeug min version
    * flask-alembic >= v3.0.0 (dependency of invenio-db) needs flask>=3.0.
      flask-alembic >= v3.0.0 is required because otherwise the removable
      of 'db' property in flask-sqlalchemy is a problem
    * the test if could be removed because of the min version now supported
    jws: move functionality from itsdangerous
    * itsdangerous v2.1.0 removes the jws functionality. to have an easy
      follow up without rewrite the functionality has been copy pasted
    setup: remove upper pins

📁 invenio-cache (1.3.1 -> 2.0.0 ⚠️)

    release: v2.0.0
    setup: replace invenio-accounts with flask-login
    * this breaks circular dependencies
    setup: bump major dependencies

📁 invenio-celery (1.3.2 -> 2.0.0 ⚠️)

    release: v2.0.0
    setup: change to reusable workflows
    setup: bump invenio dependencies
    fix: celery deprecation warning

    * CPendingDeprecationWarning: The broker_connection_retry configuration
      setting will no longer determine whether broker connection retries are
      made during startup in Celery 6.0 and above. If you wish to retain the
      existing behavior for retrying connections on startup, you should set
      broker_connection_retry_on_startup to True.

    * https://github.com/celery/celery/discussions/8314
    setup: increase celery dep

📁 invenio-communities (17.8.1 -> 18.0.0 ⚠️)

    📦 release: v18.0.0
    installation: bump invenio-requests and invenio-vocabularies
    📦 release: v18.0.0.dev2
    installation: bump requests and vocabularies
    release: v18.0.0.dev1
    fix: docs reference target not found
    setup: change to reusable workflows
    setup: bump major dependencies
    administration: fix UI

📁 invenio-db (1.3.1 -> 2.0.0 ⚠️)

    release: v2.0.0
    uow: possible solution for the rollback problem

    * the rollback should only rollback whats in that savepoint. using
      session.begin_nested creates a subtransaction which can then
      rolledback
    fix: select of BinaryExpressions

    * sqlalchemy.exc.ArgumentError: Column expression, FROM clause, or other
      columns clause element expected, got
      [<sqlalchemy.sql.elements.BinaryExpression object at 0x7fa3a0>,
      <sqlalchemy.sql.elements.BinaryExpression object at 0x7fa3ad246690>].
      Did you mean to say select(<sqlalchemy.sql.elements.BinaryExpression
      object at 0x7fa3b1145c10>, <sqly.sql.elements.BinaryExpression object at
      0x7fa3ad246690>)

      don't give the array to the select but give the elements to the select
      method

    * AttributeError: 'Engine' object has no attribute 'execute' -> change
      to session

    * TypeError: scoped_session.execute() got an unexpected keyword argument
      'a' -> change to dict
    setup: increase flask-alembic

    * flask-alembic >= 3.0 needs flask >= 3.0 and flask-sqlalchemy >= 3.0

    * added some explanation comments

    * apply db.session.query over Model.query syntax
    setup: increase min sqlalchemy dependency
    cli: password is per default hided

    * this leads to the problem that the program couldn't connect to the
      database
    refactor: move MockEntryPoint to independent file

    * this change makes it possible to import the MockEntryPoints from an
      independend file. this class is used in two tests but defined in one
      of them. placing it into a separated file makes it independent.
    setup: remove upper pins
    fix: VARCHAR needs length on mysql
    fix: remove warning and black problems

    * remove warning by using StringEncryptedType instead of EncryptedType.
      This removes a warning and there is further a notice in the code that
      the base type of EncryptedType will change in the future and it is
      better to replace it with StringEncryptedType
    fix: WeakKeyDictionary

    * the error indicates that db.init_app is not called, but it is and it
      works in other contexts. It may that the `db = invenio_db = shared.db`
      line in conftest.py is not working as expected anymore. The only found
      solution is this. The drawback is, if that is the only solution it has
      to be done also in the other packages which are using this function.
      With the default value it is backward compatible but as the tests
      indicates it may not work without adding the db parameter to the
      function call
    change: add proxy file

    * use the proxy file instead of creating the _db variable in both files

    * this removes a DeprecationWarning from flask-sqlalchemy, which
      states that the support of the use '.db' will be removed
    change: remove click 3 compatibility
    fix: tests LocalProxy

    * it is not working anymore with localproxy and it seams not necessary
    setup: increase flask-sqlalchemy version

📁 invenio-drafts-resources (5.1.0 -> 6.0.0 ⚠️)

    release: v6.0.0
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-files-rest (2.2.4 -> 3.0.0 ⚠️)

    release: v3.0.0
    filename: replace encoding/decoding
    fix: alembic assert error

    * AssertionError: assert not [[('modify_type', None, 'files_objecttags',
      'key', {'existing_comment': None, 'existing_nullable': False,
      'existing_server_default': False}, TEXT(), ...)]]

    * newer sqlalchemy + alembic is complaining about the mismatch between
      model and alembic recipe
    fix: max content type
    fix: werkzeug changed raise handling for tests

    * werkzeug is not more raising exceptions but giving it to the response
      which is more like http requests work
    fix: docs reference target not found
    fix: filename is marked as byte
    setup: bump invenio dependencies

📁 invenio-formatter (2.0.4 -> 3.0.0 ⚠️)

    release: v3.0.0
    setup: bump major dependencies

📁 invenio-github (1.5.4 -> 2.0.0 ⚠️)

    release: v2.0.0
    comp: make compatible to flask-sqlalchemy>=3.1
    setup: bump major dependencies

📁 invenio-i18n (2.2.0 -> 3.0.0 ⚠️)

    release: v3.0.0
    setup: update dependencies

📁 invenio-indexer (2.4.0 -> 3.0.0 ⚠️)

    release: v3.0.0
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-jobs (1.1.1 -> 3.0.0 ⚠️)

    📦 release: v3.0.0
    installation: bump invenio-users-resources
    📦 release: v3.0.0.dev2
    installation: bump invenio-users-resources
    release: v3.0.0.dev1
    fix: tests by skipping alembic
    fix: alembic problem

    * ('modify_type', None, 'jobs_run', 'status', {'existing_comment': None,
      'existing_nullable': False, 'existing_server_default': False},
      CHAR(length=1), ...)]])
    comp: make compatible to flask-sqlalchemy>=3.1
    setup: change to reusable workflows
    setup: bump major dependencies
    tasks: use utcnow
    📦 release: v1.1.1
    tasks: use utcnow
    release: v2.0.0
    job: refactor args

    * adds PredefinedArgsSchema schema class with predefined args, including
      `since`.
    * changes JobType public/private interface to make it easier to define
      your own job types
    * logs celery tasks error message and shows it in the UI
    * removes unused code

📁 invenio-jsonschemas (1.1.5 -> 2.0.0 ⚠️)

    release: v2.0.0
    fix: JsonRef not serializable

    * TypeError: Object of type JsonRef is not JSON serializable
    setup: bump major dependencies

📁 invenio-logging (2.1.4 -> 4.0.2 ⚠️)

    📦 release: v4.0.2
    sentry: move imports inside extension class initializer
    📦 release: v2.1.4
    sentry: move imports inside extension class initializer
    📦 release: v4.0.1
    sentry: import-detect sentry_sdk usage
    📦 release: v2.1.3
    sentry: import-detect sentry_sdk usage
    release: v3.0.0
    setup: bump invenio dependencies
    release: v3.0.0
    setup: change sentry_sdk to sentry

    * sentry_sdk could make problem, sentry-sdk too. last release had to be
      yanked because of that problem. changing to sentry only should fix it

📁 invenio-mail (2.2.0 -> 2.2.1 🐛)

    release: v2.2.1
    upgrade CI
    Add filename of attachments (inveniosoftware/invenio-mail#68)

📁 invenio-notifications (0.6.1 -> 1.0.0 ⚠️)

    release: v1.0.0
    setup: bump major dependencies

📁 invenio-oaiserver (2.3.0 -> 3.1.0 ⚠️)

    📦 release: v3.1.0
    percolator: use `OAISERVER_RECORD_INDEX` to determine percolator index

    * Instead of relying on the default `RecordIndexer` class to determine
      the percolator index, we reuse the `OAISERVER_RECORD_INDEX` config variable.
    📦 release: v2.3.0
    percolator: use `OAISERVER_RECORD_INDEX` to determine percolator index

    * Instead of relying on the default `RecordIndexer` class to determine
      the percolator index, we reuse the `OAISERVER_RECORD_INDEX` config variable.
    setup: change to reusable workflows
    release: v3.0.0
    fix: tests, apply invenio-indexer change
    fix: docs reference target not found
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-oauth2server (2.3.1 -> 3.0.2 ⚠️)

    📦 release: v3.0.2
    refactor: copy code from flask-oauthlib-invenio

    * the problem is that request.form triggers parsing the form. parsing
      the form triggers checking the max_content_length. if a file greater
      then the allowed filesize is uploaded this raises the
      RequestEntityTooLarge exception

    * to verify the request the body is not used, the token is used for
      verification
    release: v3.0.1
    fix: update iter_choices to include additional parameter in SelectSUI
    release: v3.0.0
    setup: move to flask-oauthlib-invenio
    global: replace werkzeug.url with urllib.parse

    * replacing werkzeug.url with urllib.parse makes also _compat and
      monkeypatching obsolete and therefore has been removed
    fix: LegacyAPIWarning

    * The Query.get() method is considered legacy as of the 1.x series of
      SQLAlchemy and becomes a legacy construct in 2.0. The method is now
      available as Session.get() (deprecated since: 2.0) (Background on
      SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    fix: DeprecationWarning:

    * The 'EncryptedType' class will change implementation from
      'LargeBinary' to 'String' in a future version. Use 'StringEncryptedType'
      to use the 'String' implementation.
    setup: bump major dependencies
    release: v2.4.1
    setup: change to reusable workflows
    setup: pin dependencies
    release: v2.4.0
    global: remove six usage

    * replace six with builtin
    compatibility: to werkzeug >= 2.3.0
    setup: unpin wtforms dependency

    * wtforms: apply changed api
    fix: DeprecationWarning HTMLString

    * 'HTMLString' will be removed in WTForms 3.0. Use 'markupsafe.Markup'
      instead.

    * this is a step to remove the upper pin to <= 3.0.0
    Settings: update page to reflect additional required parameter

📁 invenio-oauthclient (4.1.3 -> 5.1.0 ⚠️)

    release: v5.1.0
    fix: DeprecationWarning:

    * The 'EncryptedType' class will change implementation from
      'LargeBinary' to 'String' in a future version. Use 'StringEncryptedType'
      to use the 'String' implementation.
    fix: TypeError

    * op.execute() takes 2 positional arguments but 3 were given
    setup: move to flask-oauthlib-invenio
    release: v5.0.0
    fix: sqlalchemy.exc.ArgumentError:

    * Strings are not accepted for attribute names in loader options; please
      use class-bound attributes directly.

    * sqlalchemy >= 2.0
    global: use invenio_base.jws not itsdangerous
    setup: bump major dependencies

📁 invenio-pages (4.1.2 -> 5.0.0 ⚠️)

    release: v5.0.0
    comp: make compatible to flask-sqlalchemy>=3.1
    setup: bump major dependencies

📁 invenio-pidstore (1.3.4 -> 2.0.0 ⚠️)

    release: v2.0.0
    fix: docs reference target not found
    setup: bump invenio dependencies

📁 invenio-previewer (2.2.2 -> 3.0.0 ⚠️)

    release: v3.0.0
    fix: tests, compatibility with sqlalchemy>=2

    * session handling problem
    setup: bump major dependencies
    release: v2.3.0
    zip: move fullscreen.js to fix the zip previewer

    * the zip previewer still referenced fullscreen.js via its old location
    * move the open_pdf.js as well, to not have a directory for a single
      file
    pdfjs: upgrade to pdf.js v4

    * the new assets are basically vanilla js targeting the browser already
    * this doesn't require a build step and allows the assets to be placed
      in the static directory, avoiding a build step and allowing for
      deduplication across themes
    * the jinja template is also deduplicated similarly, by being placed
      outside of any theme directory
    * implemented functionality with pdfjs-dist v4:

📁 invenio-rdm-records (16.7.0 -> 17.0.1 ⚠️)

    📦 release: v17.0.1
    installation: bump dev deps to stable
    📦 release: v17.0.0
    📦 release: v17.0.0.dev2
    installation: bump jobs, communities, and vocabularies
    release: v17.0.0.dev1
    fix: flask-sqlalchemy.pagination >= 3.0.0
    * this is a compatibility fix. the old compatibility commit was wrong.
      they are not interchangable
    comp: make compatible to flask-sqlalchemy>=3.1
    setup: change to reusable workflows
    setup: bump major dependencies
    serializers: DataCite to DCAT-AP: fix undefined variable $cheme for relation type has metadata
    resources: update files test
    services: proper escape the fields key in links generation
    UISerializer: add polygon locations to serializer in addition to points
    * Allow UISerializer to serialize Polygon locations in addition to Points.
    * Consolidate test cases and fixtures
    release: v16.8.0
    resources: expose record revisions
    release: v16.7.1
    optional-doi: fix new upload disabled states

📁 invenio-records (2.4.1 -> 3.0.2 ⚠️)

    release: v3.0.2
    fix: the correct handling is done in the iterator

    * the thinking of handling negative revision numbers in this line with
      the list was wrong
    release: v3.0.1
    fix: alembic recipe column not altered

    * produces error on the ext.alembic.compare_metadata() test on other
      packages
    release: v3.0.0
    fix: docs reference target not found
    fix: IndexError: negative indexes not allowed

    * IndexError: negative indexes are not accepted by SQL index / slice
      operators

    * sqlalchemy >= 2.0.0 removed the possibility to have negative indices
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-records-permissions (0.22.0 -> 1.0.0 ⚠️)

    release: v1.0.0
    setup: bump major dependencies

📁 invenio-records-resources (6.5.0 -> 7.0.1 ⚠️)

    📦 release: v7.0.1
    fix: file upload >100MB

    * flask uses now the MAX_CONTENT_LENGTH to restrict file upload. it is
      possible to set the max_content_length per request. so for this request
      it is set to the configured max file size
    release: v7.0.0
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-records-rest (2.4.1 -> 3.0.0 ⚠️)

    release: v3.0.0
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-records-ui (1.2.2 -> 2.0.0 ⚠️)

    release: v2.0.0
    setup: bump major dependencies

📁 invenio-requests (5.5.0 -> 6.0.0 ⚠️)

    📦 release: v6.0.0
    installation: bump invenio-users-resources
    📦 release: v6.0.0.dev2
    installation: bump invenio-users-resources
    release: v6.0.0.dev1
    fix: sqlalchemy.exc.ArgumentError

    * Textual SQL expression 'SELECT setval(pg_get_seri...' should be
      explicitly declared as text('SELECT setval(pg_get_seri...')
    comp: make compatible to flask-sqlalchemy>=3.1
    setup: bump major dependencies

📁 invenio-rest (1.5.0 -> 2.0.0 ⚠️)

    release: v2.0.0
    fix: set_cookie needs a str
    fix: cookie_jar not in FlaskClient

    * there was a refactoring done in werkzeug see
      https://github.com/pallets/werkzeug/pull/2637
    fix: set_cookie needs a str

    * but the tests are using the _get_new_csrf_token directly too and then
      a byte value is returned which is wrong
    global: remove try except for jws

    * increase itsdangerous and use invenio-base for jws now exclusively
      since invenio-base has been upgraded to >=2.0.0
    setup: bump major dependencies

📁 invenio-search (2.4.1 -> 3.0.0 ⚠️)

    release: v3.0.0
    fix: tests

    * that is a proactive fix. it happens locally but not really on github.
      this should be reconsidered.
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-search-ui (3.0.1 -> 4.0.0 ⚠️)

    release: v4.0.0
    refactor: blueprint creation to new style
    setup: bump major dependencies

📁 invenio-stats (4.3.0 -> 5.1.0 ⚠️)

    release: v5.1.0
    release: v4.3.0
    aggregations: add yearly interval
    release: v5.0.0
    setup: bump major dependencies

📁 invenio-theme (3.6.1 -> 4.1.0 ⚠️)

    release: v4.1.0
    theme: expand generator classes
    📦 release: v4.0.1
    form: some UI fixed for the deposit form
    release: v4.0.0
    setup: bump major dependencies

📁 invenio-userprofiles (3.0.2 -> 4.0.0 ⚠️)

    release: v3.0.2
    fixed 404 issue when pressing cancel
    release: v4.0.0
    setup: bump major dependencies

📁 invenio-users-resources (6.1.3 -> 7.0.0 ⚠️)

    📦 release: v7.0.0
    📦 release: v7.0.0.dev2
    release: v7.0.0.dev1
    setup: change to reusable workflows
    setup: bump major dependencies

📁 invenio-vocabularies (6.11.0 -> 7.0.0 ⚠️)

    📦 release: v7.0.0
    installation: bump invenio-jobs
    📦 release: v7.0.0.dev2
    installation: bump invenio-jobs
    release: v7.0.0.dev1
    comp: make compatible to flask-sqlalchemy>=3.1
    setup: change to reusable workflows
    setup: bump major dependencies
    jobs: apply code upgrades
