### PR TITLE
globals: site.overrides: remove custom PDF preview iframe height

### DIFF
--- a/assets/less/zenodo-rdm/globals/site.overrides
+++ b/assets/less/zenodo-rdm/globals/site.overrides
@@ -164,8 +164,3 @@ a.inverted {
 .cookie-banner.hidden {
   display: none !important;
 }
-
-.preview-iframe {
-  height:60vh;
-}
-


### PR DESCRIPTION
This change has been implemented in invenio-app-rdm: see inveniosoftware/invenio-app-rdm#2961