### PR TITLE
legacy: fix thumb250 link generation

### DIFF
--- a/site/zenodo_rdm/legacy/services.py
+++ b/site/zenodo_rdm/legacy/services.py
@@ -164,6 +164,7 @@ class LegacyRecordServiceConfig(RDMRecordServiceConfig):
         "thumb250": RecordEndpointLink(
             "invenio_redirector.redirect_record_thumbnail",
             vars=lambda _, v: v.update({"size": "250"}),
+            params=["pid_value", "size"],
             when=is_iiif_compatible,
         ),
         "thumbs": LegacyThumbsLink(


### PR DESCRIPTION
* We need to explicitly mention additional parameters like "size" when
  using the `RecordEndpointLink`.
