### PR TITLE
openaire: fix OpenAIRE EXPLORE link generation

### DIFF
--- a/site/tests/openaire/test_openaire_helpers.py
+++ b/site/tests/openaire/test_openaire_helpers.py
@@ -108,4 +108,4 @@ def test_openaire_link(running_app, minimal_open_record, resource_type, oatype):
         "oai": {"identifier": "oai:zenodo.org:123"},
     }
     r["metadata"]["resource_type"] = {"id": resource_type}
-    assert openaire_link(r) == f"https://explore.openaire.eu/search/{oatype}?pid={doi}"
+    assert openaire_link(r) == f"https://explore.openaire.eu/search/result?pid={doi}"

--- a/site/zenodo_rdm/openaire/utils.py
+++ b/site/zenodo_rdm/openaire/utils.py
@@ -146,12 +146,10 @@ def openaire_request_factory(headers=None, auth=None):
 
 
 def openaire_link(record):
-    """Compute an OpenAIRE link."""
-    oatype = openaire_type(record)
+    """Generate an OpenAIRE link."""
     doi = record.get("pids", {}).get("doi", {}).get("identifier")
-
     openaire_url = current_app.config["OPENAIRE_PORTAL_URL"]
 
-    if oatype and doi:
-        return f"{openaire_url}/search/{oatype}?pid={urllib.parse.quote(str(doi))}"
+    if doi:
+        return f"{openaire_url}/search/result?pid={urllib.parse.quote(str(doi))}"
     return None


### PR DESCRIPTION
* We can now use the much simpler `/search/result?pid=...` endpoint,
  which works independent of the record's resource type.
