### PR TITLE
fix(support): move to separate blueprint

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -952,7 +952,7 @@ RATELIMIT_PER_ENDPOINT = {
     "invenio_github_badge.latest_doi": "120 per minute",
     "invenio_github_badge.latest_doi_old": "120 per minute",
     # Support
-    "zenodo_rdm.support_form": "10 per second",
+    "zenodo_support.index": "10 per second",
     # Login and registration
     "invenio_oauthclient.login": "10 per minute",
     "invenio_oauthclient.signup": "10 per minute",

--- a/site/pyproject.toml
+++ b/site/pyproject.toml
@@ -9,7 +9,8 @@ moderation = "zenodo_rdm.cli:moderation_cli"
 exporter = "zenodo_rdm.exporter.cli:exporter"
 
 [project.entry-points."invenio_base.blueprints"]
-zenodo_rdm_support = "zenodo_rdm.views:create_blueprint"
+zenodo_rdm = "zenodo_rdm.views:create_blueprint"
+zenodo_support = "zenodo_rdm.support.views:create_blueprint"
 
 [project.entry-points."invenio_base.apps"]
 zenodo_rdm_legacy = "zenodo_rdm.legacy.ext:ZenodoLegacy"

--- a/site/tests/support/test_contact_form.py
+++ b/site/tests/support/test_contact_form.py
@@ -10,7 +10,7 @@
 import pytest
 from marshmallow import ValidationError
 
-from zenodo_rdm.support.support import ZenodoSupport
+from zenodo_rdm.support.views import ZenodoSupport
 
 
 @pytest.fixture
@@ -40,7 +40,7 @@ def test_form_validation_valid(form_json_data, support_view, test_app):
     """Tests form with valid data."""
     validated_data = support_view.validate_form(form_json_data)
     assert validated_data
-    assert type(validated_data) == dict
+    assert isinstance(validated_data, dict)
     assert validated_data == form_json_data
 
 

--- a/site/zenodo_rdm/views.py
+++ b/site/zenodo_rdm/views.py
@@ -11,11 +11,9 @@ from invenio_communities.proxies import current_communities
 from invenio_rdm_records.proxies import current_rdm_records
 from invenio_rdm_records.resources.serializers import UIJSONSerializer
 from invenio_records_resources.resources.records.utils import search_preference
-from marshmallow import ValidationError
 
 from .decorators import cached_unless_authenticated_or_flashes
 from .filters import is_blr_related_record, is_verified_community, is_verified_record
-from .support.support import ZenodoSupport
 
 
 #
@@ -60,33 +58,11 @@ def frontpage_view_function():
 #
 def create_blueprint(app):
     """Register blueprint routes on app."""
-
-    @app.errorhandler(ValidationError)
-    def handle_validation_errors(e):
-        if isinstance(e, ValidationError):
-            dic = e.messages
-            deserialized = []
-            for error_tuple in dic.items():
-                field, value = error_tuple
-                deserialized.append({"field": field, "messages": value})
-            return {"errors": deserialized}, 400
-        return e.message, 400
-
     blueprint = Blueprint(
         "zenodo_rdm",
         __name__,
         template_folder="./templates",
     )
-
-    # Support URL rule
-    support_endpoint = app.config["SUPPORT_ENDPOINT"] or "/support"
-    blueprint.add_url_rule(
-        support_endpoint,
-        view_func=ZenodoSupport.as_view("support_form"),
-        strict_slashes=False,
-    )
-
-    app.register_error_handler(400, handle_validation_errors)
 
     # Register template filters
     blueprint.add_app_template_filter(is_blr_related_record)


### PR DESCRIPTION
We used to register error handlers for both 400 and `ValidationError`
responses on the **global** Flask UI application. Depending on app
initialization order this could very likely conflict with other error
handlers.

Now the support view is on its separate blueprint which properly scopes
error handling to it.
