### PR TITLE
fix(mappings): add `swh` field via index template

### DIFF
--- a/site/tests/conftest.py
+++ b/site/tests/conftest.py
@@ -26,7 +26,6 @@ from invenio_vocabularies.contrib.awards.api import Award
 from invenio_vocabularies.contrib.funders.api import Funder
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from invenio_vocabularies.records.api import Vocabulary
-
 from zenodo_rdm.api import ZenodoRDMDraft, ZenodoRDMRecord
 from zenodo_rdm.custom_fields import CUSTOM_FIELDS, CUSTOM_FIELDS_UI, NAMESPACES
 from zenodo_rdm.generators import media_files_management_action
@@ -84,6 +83,22 @@ def app_config(app_config):
     app_config["TILES_GENERATION_ENABLED "] = False
 
     return app_config
+
+
+@pytest.fixture(scope="module")
+def search(search):
+    from invenio_search import current_search, current_search_client
+    from invenio_search.engine import search
+
+    try:
+        list(current_search.put_templates())
+        list(current_search.put_index_templates())
+    except search.RequestError:
+        pass
+
+    current_search_client.indices.refresh()
+    yield search
+    # Cleanup?
 
 
 @pytest.fixture(scope="function")

--- a/site/zenodo_rdm/index_templates/os-v2/rdmrecords-template.json
+++ b/site/zenodo_rdm/index_templates/os-v2/rdmrecords-template.json
@@ -1,9 +1,23 @@
 {
   "priority": 100,
-  "index_patterns": ["__SEARCH_INDEX_PREFIX__rdmrecords-*"],
+  "index_patterns": [
+    "__SEARCH_INDEX_PREFIX__rdmrecords-*"
+  ],
   "template": {
     "settings": {
-        "number_of_shards": 3
+      "number_of_shards": 3
+    },
+    "mappings": {
+      "properties": {
+        "swh": {
+          "type": "object",
+          "properties": {
+            "swhid": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
To make sure we always create the `swh` property in the records
mappings, we can use an index template.
