### PR TITLE
Fix SWH and DataCite/BibTex serialization

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -75,7 +75,6 @@ from zenodo_rdm.custom_fields import (
 from zenodo_rdm.custom_schemes import is_edmo
 from zenodo_rdm.files import storage_factory
 from zenodo_rdm.github.schemas import CitationMetadataSchema
-from zenodo_rdm.legacy.resources import record_serializers
 from zenodo_rdm.metrics.config import METRICS_CACHE_UPDATE_INTERVAL
 from zenodo_rdm.moderation.errors import UserBlockedException
 from zenodo_rdm.moderation.handlers import (
@@ -88,6 +87,8 @@ from zenodo_rdm.permissions import (
     ZenodoRDMRecordPermissionPolicy,
 )
 from zenodo_rdm.queryparser import word_communities, word_doi
+from zenodo_rdm.subcommunities import (
+from zenodo_rdm.resources import record_serializers
 from zenodo_rdm.subcommunities import (
     ZenodoSubCommunityInvitationRequest,
     ZenodoSubCommunityRequest,

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -87,7 +87,6 @@ from zenodo_rdm.permissions import (
     ZenodoRDMRecordPermissionPolicy,
 )
 from zenodo_rdm.queryparser import word_communities, word_doi
-from zenodo_rdm.subcommunities import (
 from zenodo_rdm.resources import record_serializers
 from zenodo_rdm.subcommunities import (
     ZenodoSubCommunityInvitationRequest,
@@ -400,11 +399,14 @@ RDM_RECORDS_ERROR_HANDLERS = {
     ),
 }
 
+RDM_PERSISTENT_IDENTIFIER_PROVIDERS = (
+    zenodo_providers.RDM_PERSISTENT_IDENTIFIER_PROVIDERS
+)
+RDM_PARENT_PERSISTENT_IDENTIFIERS = zenodo_providers.RDM_PARENT_PERSISTENT_IDENTIFIERS
 RDM_PARENT_PERSISTENT_IDENTIFIER_PROVIDERS = (
     zenodo_providers.RDM_PARENT_PERSISTENT_IDENTIFIER_PROVIDERS
 )
 RDM_PARENT_PERSISTENT_IDENTIFIERS = zenodo_providers.RDM_PARENT_PERSISTENT_IDENTIFIERS
-
 
 RDM_RESOURCE_ACCESS_TOKENS_ENABLED = True
 RDM_RESOURCE_ACCESS_TOKEN_REQUEST_ARG = "resource-token"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zenodo-rdm-app"
-version = "20.2.3"
+version = "20.2.4"
 authors = [
     { name = "CERN" }
 ]
@@ -28,7 +28,7 @@ dependencies = [
 [tool.uv.sources]
 zenodo-rdm = { workspace = true }
 zenodo-legacy = { workspace = true }
-invenio-swh = { git = "https://github.com/inveniosoftware/invenio-swh", rev = "v0.13.3" }
+invenio-swh = { git = "https://github.com/inveniosoftware/invenio-swh", rev = "v0.13.4" }
 invenio-records-resources = { git = "https://github.com/inveniosoftware/invenio-records-resources", branch = "fix-read-many" }
 invenio-users-resources = { git = "https://github.com/inveniosoftware/invenio-users-resources", rev = "d421cb341c23539f3f7376103128b990706fd168" }
 
@@ -40,6 +40,7 @@ members = [
 
 [dependency-groups]
 dev = [
+    "pdbpp>=0.11.7",
     "pytest-invenio>=3.0.0,<4.0.0",
 ]
 

--- a/site/tests/conftest.py
+++ b/site/tests/conftest.py
@@ -31,8 +31,8 @@ from zenodo_rdm.api import ZenodoRDMDraft, ZenodoRDMRecord
 from zenodo_rdm.custom_fields import CUSTOM_FIELDS, CUSTOM_FIELDS_UI, NAMESPACES
 from zenodo_rdm.generators import media_files_management_action
 from zenodo_rdm.legacy.requests.record_upgrade import LegacyRecordUpgrade
-from zenodo_rdm.legacy.resources import record_serializers
 from zenodo_rdm.permissions import ZenodoRDMRecordPermissionPolicy
+from zenodo_rdm.resources import record_serializers
 
 from .fake_datacite_client import FakeDataCiteClient
 

--- a/site/zenodo_rdm/communities_ui/views/communities.py
+++ b/site/zenodo_rdm/communities_ui/views/communities.py
@@ -16,9 +16,7 @@ from invenio_communities.views.communities import (
     render_community_theme_template,
 )
 from invenio_communities.views.decorators import pass_community
-from invenio_rdm_records.proxies import (
-    current_community_records_service,
-)
+from invenio_rdm_records.proxies import current_community_records_service
 from invenio_rdm_records.resources.serializers import UIJSONSerializer
 from invenio_records_resources.services.errors import PermissionDeniedError
 

--- a/site/zenodo_rdm/exporter/tasks.py
+++ b/site/zenodo_rdm/exporter/tasks.py
@@ -11,7 +11,6 @@ import csv
 import gzip
 import json
 import tarfile
-from datetime import datetime
 from io import BytesIO, TextIOWrapper
 
 from celery import shared_task
@@ -20,12 +19,7 @@ from flask_principal import AnonymousIdentity, identity_changed
 from invenio_access.permissions import any_user
 from invenio_communities.communities.records.models import CommunityMetadata
 from invenio_db import db
-from invenio_files_rest.models import (
-    Bucket,
-    Location,
-    ObjectVersion,
-    as_bucket,
-)
+from invenio_files_rest.models import Bucket, Location, ObjectVersion, as_bucket
 from invenio_rdm_records.oai import oai_datacite_etree
 from invenio_rdm_records.proxies import current_rdm_records_service as service
 from lxml import etree
@@ -43,7 +37,6 @@ def _get_anonymous_identity():
 
 
 def _export_records_to_files(format, community_slug, records_file, deleted_file):
-
     community_uuid = None
 
     if community_slug:
@@ -183,11 +176,10 @@ def export_records(format, community_slug):
     records_file_stream = BytesIO()
     deleted_file_stream = BytesIO()
 
-    with tarfile.open(
-        fileobj=records_file_stream, mode="w|gz"
-    ) as records_file, gzip.GzipFile(
-        fileobj=deleted_file_stream, mode="w"
-    ) as deleted_file:
+    with (
+        tarfile.open(fileobj=records_file_stream, mode="w|gz") as records_file,
+        gzip.GzipFile(fileobj=deleted_file_stream, mode="w") as deleted_file,
+    ):
         _export_records_to_files(format, community_slug, records_file, deleted_file)
 
     records_file_stream.seek(0)

--- a/site/zenodo_rdm/legacy/resources.py
+++ b/site/zenodo_rdm/legacy/resources.py
@@ -7,7 +7,6 @@
 
 """Zenodo legacy resources."""
 
-import copy
 from functools import partial, wraps
 
 import marshmallow as ma
@@ -26,9 +25,6 @@ from invenio_rdm_records.resources.config import (
     RDMDraftFilesResourceConfig,
     RDMRecordMediaFilesResourceConfig,
     RDMRecordResourceConfig,
-)
-from invenio_rdm_records.resources.config import (
-    record_serializers as default_record_serializers,
 )
 from invenio_rdm_records.resources.resources import RDMRecordResource
 from invenio_records_resources.resources.files.resource import (
@@ -51,23 +47,6 @@ from .serializers import (
     LegacyDraftFileJSONSerializer,
     LegacyFilesRESTJSONSerializer,
     LegacyJSONSerializer,
-    ZenodoJSONSerializer,
-)
-
-record_serializers = copy.deepcopy(default_record_serializers)
-record_serializers.update(
-    {
-        "application/json": ResponseHandler(
-            ZenodoJSONSerializer(), headers=etag_headers
-        ),
-        "application/vnd.zenodo.v1+json": ResponseHandler(
-            ZenodoJSONSerializer(), headers=etag_headers
-        ),
-        # Alias for the DataCite XML serializer
-        "application/x-datacite+xml": record_serializers[
-            "application/vnd.datacite.datacite+xml"
-        ],
-    }
 )
 
 

--- a/site/zenodo_rdm/permissions.py
+++ b/site/zenodo_rdm/permissions.py
@@ -31,9 +31,7 @@ from invenio_records_permissions.generators import (
     SystemProcess,
 )
 from invenio_records_resources.services.files.generators import IfTransferType
-from invenio_records_resources.services.files.transfer import (
-    LOCAL_TRANSFER_TYPE,
-)
+from invenio_records_resources.services.files.transfer import LOCAL_TRANSFER_TYPE
 from invenio_users_resources.services.permissions import UserManager
 
 from .generators import (

--- a/site/zenodo_rdm/resources.py
+++ b/site/zenodo_rdm/resources.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 CERN.
+#
+# Zenodo is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+import copy
+
+from flask_resources import ResponseHandler
+from invenio_rdm_records.resources.config import (
+    record_serializers as default_record_serializers,
+)
+from invenio_records_resources.resources.records.headers import etag_headers
+
+from . import serializers
+from .legacy.serializers import ZenodoJSONSerializer
+
+record_serializers = copy.deepcopy(default_record_serializers)
+record_serializers.update(
+    {
+        "application/json": ResponseHandler(
+            ZenodoJSONSerializer(), headers=etag_headers
+        ),
+        "application/vnd.zenodo.v1+json": ResponseHandler(
+            ZenodoJSONSerializer(), headers=etag_headers
+        ),
+        "application/vnd.datacite.datacite+xml": ResponseHandler(
+            serializers.ZenodoDataciteXMLSerializer(), headers=etag_headers
+        ),
+        "application/vnd.datacite.datacite+json": ResponseHandler(
+            serializers.ZenodoDataciteJSONSerializer(), headers=etag_headers
+        ),
+        "application/x-bibtex": ResponseHandler(
+            serializers.ZenodoBibtexSerializer(), headers=etag_headers
+        ),
+    }
+)
+
+# Alias for the DataCite XML serializer
+record_serializers["application/x-datacite+xml"] = record_serializers[
+    "application/vnd.datacite.datacite+xml"
+]

--- a/site/zenodo_rdm/resources.py
+++ b/site/zenodo_rdm/resources.py
@@ -5,6 +5,8 @@
 # Zenodo is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
+"""Zenodo resources config."""
+
 import copy
 
 from flask_resources import ResponseHandler

--- a/uv.lock
+++ b/uv.lock
@@ -976,6 +976,19 @@ wheels = [
 ]
 
 [[package]]
+name = "fancycompleter"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
+    { name = "pyrepl", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/4c/d11187dee93eff89d082afda79b63c79320ae1347e49485a38f05ad359d0/fancycompleter-0.11.1.tar.gz", hash = "sha256:5b4ad65d76b32b1259251516d0f1cb2d82832b1ff8506697a707284780757f69", size = 341776, upload-time = "2025-05-26T12:59:11.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/c3/6f0e3896f193528bbd2b4d2122d4be8108a37efab0b8475855556a8c4afa/fancycompleter-0.11.1-py3-none-any.whl", hash = "sha256:44243d7fab37087208ca5acacf8f74c0aa4d733d04d593857873af7513cdf8a6", size = 11207, upload-time = "2025-05-26T12:59:09.857Z" },
+]
+
+[[package]]
 name = "fastjsonschema"
 version = "2.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2477,8 +2490,8 @@ wheels = [
 
 [[package]]
 name = "invenio-swh"
-version = "0.13.3"
-source = { git = "https://github.com/inveniosoftware/invenio-swh?rev=v0.13.3#c102421e2bbc99a08d5df73ceb7b31e72f12bbed" }
+version = "0.13.4"
+source = { git = "https://github.com/inveniosoftware/invenio-swh?rev=v0.13.4#828a3a415cf8e725c369939832b61281c44aec40" }
 dependencies = [
     { name = "invenio-access" },
     { name = "invenio-db" },
@@ -3257,14 +3270,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.1.3"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/79/bda47f7dd7c3c55770478d6d02c9960c430b0cf1773b72366ff89126ea31/mistune-3.1.3.tar.gz", hash = "sha256:a7035c21782b2becb6be62f8f25d3df81ccb4d6fa477a6525b15af06539f02a0", size = 94347, upload-time = "2025-03-19T14:27:24.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/02/a7fb8b21d4d55ac93cdcde9d3638da5dd0ebdd3a4fed76c7725e10b81cbe/mistune-3.1.4.tar.gz", hash = "sha256:b5a7f801d389f724ec702840c11d8fc48f2b33519102fc7ee739e8177b672164", size = 94588, upload-time = "2025-08-29T07:20:43.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/4d/23c4e4f09da849e127e9f123241946c23c1e30f45a88366879e064211815/mistune-3.1.3-py3-none-any.whl", hash = "sha256:1a32314113cff28aa6432e99e522677c8587fd83e3d51c29b82a52409c842bd9", size = 53410, upload-time = "2025-03-19T14:27:23.451Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl", hash = "sha256:93691da911e5d9d2e23bc54472892aff676df27a75274962ff9edc210364266d", size = 53481, upload-time = "2025-08-29T07:20:42.218Z" },
 ]
 
 [[package]]
@@ -3610,6 +3623,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "pdbpp"
+version = "0.11.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fancycompleter" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/4c/118ef9534ac0632859b48c305d8c5dc9d6f963564fdfa66bc785c560247c/pdbpp-0.11.7.tar.gz", hash = "sha256:cb6604ac31a35ed0f2a29650a8c022b26284620be3e01cfd41b683b91da1ff14", size = 76026, upload-time = "2025-07-18T09:36:02.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/e9/704bbc08aace64fee536e4c2c20f63f64f6fdbad72938c5ed46c9723a9f1/pdbpp-0.11.7-py3-none-any.whl", hash = "sha256:51916b63693898cf4881b36b4501c83947758d73f582f1f84893662b163bdb75", size = 30545, upload-time = "2025-07-18T09:36:01.478Z" },
 ]
 
 [[package]]
@@ -4060,6 +4086,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pyrepl"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/4f/7088417e5465c53a30b918d30542aad89352ea0d635a5d077717c69a7d2b/pyrepl-0.11.4.tar.gz", hash = "sha256:efe988b4a6e5eed587e9769dc2269aeec2b6feec2f5d77995ee85b9ad7cf7063", size = 51089, upload-time = "2025-07-17T22:56:25.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/a5/ce97a778f096aaa27cfcb7ad09f1198cf73277dcab6c68a4b8f332d91e48/pyrepl-0.11.4-py3-none-any.whl", hash = "sha256:ac30d6340267a21c39e1b1934f92bca6b8735017d14b17e40f903b2d1563541d", size = 55596, upload-time = "2025-07-17T22:56:24.537Z" },
 ]
 
 [[package]]
@@ -5896,7 +5940,7 @@ source = { editable = "site" }
 
 [[package]]
 name = "zenodo-rdm-app"
-version = "20.2.3"
+version = "20.2.4"
 source = { virtual = "." }
 dependencies = [
     { name = "commonmeta-py" },
@@ -5928,6 +5972,7 @@ xrootd = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pdbpp" },
     { name = "pytest-invenio" },
 ]
 
@@ -5937,7 +5982,7 @@ requires-dist = [
     { name = "github3-py", specifier = ">=3.0.0" },
     { name = "invenio-app-rdm", extras = ["opensearch2"], specifier = "~=14.0.0b0.dev2" },
     { name = "invenio-records-resources", git = "https://github.com/inveniosoftware/invenio-records-resources?branch=fix-read-many" },
-    { name = "invenio-swh", git = "https://github.com/inveniosoftware/invenio-swh?rev=v0.13.3" },
+    { name = "invenio-swh", git = "https://github.com/inveniosoftware/invenio-swh?rev=v0.13.4" },
     { name = "invenio-users-resources", git = "https://github.com/inveniosoftware/invenio-users-resources?rev=d421cb341c23539f3f7376103128b990706fd168" },
     { name = "invenio-xrootd", marker = "extra == 'xrootd'", specifier = "==2.0.0a2" },
     { name = "nameparser", specifier = ">=1.1.1" },
@@ -5956,7 +6001,10 @@ requires-dist = [
 provides-extras = ["sentry", "xrootd"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest-invenio", specifier = ">=3.0.0,<4.0.0" }]
+dev = [
+    { name = "pdbpp", specifier = ">=0.11.7" },
+    { name = "pytest-invenio", specifier = ">=3.0.0,<4.0.0" },
+]
 
 [[package]]
 name = "zipp"
@@ -5969,9 +6017,9 @@ wheels = [
 
 [[package]]
 name = "zipstream-ng"
-version = "1.8.0"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/16/5d9224baf640214255c34a0a0e9528c8403d2b89e2ba7df9d7cada58beb1/zipstream_ng-1.8.0.tar.gz", hash = "sha256:b7129d2c15d26934b3e1cb22256593b6bdbd03c553c26f4199a5bf05110642bc", size = 35887, upload-time = "2024-10-10T05:22:33.213Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/f2/690a35762cf8366ce6f3b644805de970bd6a897ca44ce74184c7b2bc94e7/zipstream_ng-1.9.0.tar.gz", hash = "sha256:a0d94030822d137efbf80dfdc680603c42f804696f41147bb3db895df667daea", size = 37963, upload-time = "2025-08-29T01:03:36.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/81/11ecdfd5370d6c383f0188a6f2fa2842499e1be617e678d1845f972c6821/zipstream_ng-1.8.0-py3-none-any.whl", hash = "sha256:e7196cb845cf924ed12e7a3b38404ef9e82a5a699801295f5f4cf601449e2bf6", size = 23082, upload-time = "2024-10-10T05:22:31.655Z" },
+    { url = "https://files.pythonhosted.org/packages/de/62/c2da1c495291a52e561257d017585e08906d288035d025ccf636f6b9a266/zipstream_ng-1.9.0-py3-none-any.whl", hash = "sha256:31dc2cf617abdbf28d44f2e08c0d14c8eee2ea0ec26507a7e4d5d5f97c564b7a", size = 24852, upload-time = "2025-08-29T01:03:35.046Z" },
 ]


### PR DESCRIPTION
- **fix(serializers): use Zenodo DataCite and BibTex serializers consistently**
  Our custom Zenodo DataCite and BibTex serializers that contain the `swh`
  field, were only used in the record landing page export format
  serializers. This is an issue since we want that REST API and results
  and DataCite DOI registration to actually use them as well.
  
  This change moves the serializer definitions for REST APIs in a separate
  file, since having them under the legacy namespace didn't make sense.
  

- **installation: bump invenio-swh**
  📁 invenio-swh (0.13.3 -> 0.13.4 🐛)
  
      📦 release: v0.13.4
      fix(systemfields): use correct variable for loading SWHDeposit
  

- **chore: formatting and remove unused imports**
  