### PR TITLE
fix(templates): use full name for email greeting

### DIFF
--- a/templates/security/email/change_notice.html
+++ b/templates/security/email/change_notice.html
@@ -8,8 +8,9 @@
             </td>
         </tr>
         <tr>
+            {% set name = user.profile.full_name if user.profile and user.profile.full_name else user.username %}
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, %(username)s!', username=user.username) }}</p>
+                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
                 <p>{{ _('Your password has been successfully changed!') }}</p>
             </td>
         </tr>

--- a/templates/security/email/confirmation_instructions.html
+++ b/templates/security/email/confirmation_instructions.html
@@ -4,12 +4,13 @@
             <td style="padding:15px 15px 10px 15px;">
                 <a href="{{ url_for('security.login', _external=True) }}">
                     <img src="{{ url_for('static', filename='images/zenodo-gradient-1000.png', _external=True) }}" style="width:250px;border-radius:10px;"/>
-                </a>               
+                </a>
             </td>
         </tr>
         <tr>
+            {% set name = user.profile.full_name if user.profile and user.profile.full_name else user.username %}
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, %(username)s!', username=user.username) }}</p>
+                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
                 <p>{{ _('You have received this message because your email address has been registered with Zenodo.') }} </p>
                 <p>{{ _('Verify yourself and confirm your email by clicking below.') }}</p>
             </td>

--- a/templates/security/email/reset_instructions.html
+++ b/templates/security/email/reset_instructions.html
@@ -8,8 +8,9 @@
             </td>
         </tr>
         <tr>
+            {% set name = user.profile.full_name if user.profile and user.profile.full_name else user.username %}
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, %(username)s!', username=user.username) }}</p>
+                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
                 <p>{{ _('There was a request to reset your password.') }}</p>
                 <p>{{ _('If you did not make this request then please ignore this message.') }}</p>
                 <p>{{ _('Otherwise, please press the button below to change your password.') }}</p>

--- a/templates/security/email/reset_notice.html
+++ b/templates/security/email/reset_notice.html
@@ -8,8 +8,9 @@
             </td>
         </tr>
         <tr>
+            {% set name = user.profile.full_name if user.profile and user.profile.full_name else user.username %}
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, %(username)s!', username=user.username) }}</p>
+                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
                 <p>{{ _('Your password has been successfully reset!') }}</p>
             </td>
         </tr>


### PR DESCRIPTION
I think we could push this change upstream, but at the moment we don't override any of the [email templates in `invenio-accounts`](https://github.com/inveniosoftware/invenio-accounts/tree/master/invenio_accounts/templates/security/email), so they would have to be copy-pasted from `Flask-Security-Fork`. We can't push this up to `Flask-Security-Fork` also, since it doesn't know about "profiles" or full-names.