### PR TITLE
fix(permissions): allow reading draft media files

### DIFF
--- a/site/zenodo_rdm/permissions.py
+++ b/site/zenodo_rdm/permissions.py
@@ -219,7 +219,7 @@ class ZenodoRDMRecordPermissionPolicy(RDMRecordPermissionPolicy):
 
     # Media files
     can_draft_media_create_files = [MediaFilesManager(), SystemProcess()]
-    can_draft_media_read_files = can_draft_media_create_files
+    can_draft_media_read_files = can_draft_read_files
     can_draft_media_set_content_files = [
         IfTransferType(LOCAL_TRANSFER_TYPE, can_draft_media_create_files),
         SystemProcess(),


### PR DESCRIPTION
* Listing a draft's media files requires the same permission as for
  reading regular draft files, i.e. record owners and other users with
  "read"-like permissions on the draft.
* This fixes actually a permissions issue on request detail pages, where
  the owner of the draft/record wasn't able to see the page, if there
  were draft media files (e.g. PTIFF tiles for PDFs and images).
