### PR TITLE
feat(support): allow blocked users to access support form

### DIFF
--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/SupportForm.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/SupportForm.js
@@ -56,6 +56,11 @@ class SupportForm extends Component {
   constructor(props) {
     super(props);
 
+    const category = props.initialValues.category || "";
+    const matchedCategory = category
+      ? props.categories.find((c) => c.key === category) || null
+      : null;
+
     this.state = {
       fileErrorMessage: null,
       totalFileSize: 0,
@@ -63,7 +68,7 @@ class SupportForm extends Component {
       loading: false,
       errorStatus: null,
       responseData: null,
-      activeCategory: null,
+      activeCategory: matchedCategory,
     };
   }
 
@@ -131,12 +136,15 @@ class SupportForm extends Component {
       userPlatform,
       userMail,
       maxFileSize,
+      initialValues,
     } = this.props;
 
-    const initialValues = {
+    const formInitialValues = {
       email: userMail,
       name: name,
-      category: "",
+      category: initialValues.category || "",
+      subject: initialValues.subject || "",
+      description: initialValues.description || "",
       sysInfo: false,
       files: [],
     };
@@ -176,7 +184,7 @@ class SupportForm extends Component {
 
     return (
       <Formik
-        initialValues={initialValues}
+        initialValues={formInitialValues}
         onSubmit={this.onSubmit}
         validateOnChange={false}
         validateOnBlur={false}
@@ -334,6 +342,7 @@ SupportForm.propTypes = {
   categories: PropTypes.array,
   maxFileSize: PropTypes.number,
   apiEndpoint: PropTypes.string.isRequired,
+  initialValues: PropTypes.object,
 };
 
 SupportForm.defaultProps = {
@@ -343,6 +352,7 @@ SupportForm.defaultProps = {
   userPlatform: "",
   categories: [],
   maxFileSize: 1000 * 1000 * 10,
+  initialValues: {},
 };
 
 export default SupportForm;

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/support.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/support.js
@@ -15,6 +15,7 @@ const descriptionMaxLength = parseInt(domContainer.dataset.descriptionMaxLength)
 const descriptionMinLength = parseInt(domContainer.dataset.descriptionMinLength);
 const apiEndpoint = domContainer.dataset.apiEndpoint;
 const isUserAuthenticated = JSON.parse(domContainer.dataset.isAuthenticated);
+const initialValues = JSON.parse(domContainer.dataset.initialValues || "{}");
 
 ReactDOM.render(
   <SupportForm
@@ -28,6 +29,7 @@ ReactDOM.render(
     descriptionMaxLength={descriptionMaxLength}
     descriptionMinLength={descriptionMinLength}
     apiEndpoint={apiEndpoint}
+    initialValues={initialValues}
   />,
   rootContainer
 );

--- a/site/zenodo_rdm/support/views.py
+++ b/site/zenodo_rdm/support/views.py
@@ -8,6 +8,7 @@
 """Implements the support view for ZenodoRDM."""
 
 import mimetypes
+import re
 from base64 import b64encode
 from collections import OrderedDict
 
@@ -45,8 +46,14 @@ class ZenodoSupport(MethodView):
     def get(self):
         """Renders the support template."""
         valid_referrer = current_app.config["SUPPORT_VALID_REFERRER"]
+        blocked_ref = request.args.get("ref", "")
+        has_valid_ref = bool(re.fullmatch(r"[0-9a-f]{32}", blocked_ref))
         if valid_referrer is not None and request.referrer != valid_referrer:
-            return redirect(valid_referrer)
+            if not has_valid_ref:
+                return redirect(valid_referrer)
+        # Blocked users coming from the 403 page can't log in,
+        # so no need to show the login box
+        hide_login = has_valid_ref
 
         user_agent = _extract_info_from_useragent(request.headers.get("User-Agent"))
         browser_client = user_agent.get("browser", "") or "Unknown client"
@@ -54,10 +61,33 @@ class ZenodoSupport(MethodView):
         browser_string = browser_client + " " + browser_version
         platform = user_agent.get("os", "")
         system_info = {"browser": browser_string, "platform": platform}
+
+        # Form pre-fill from query params
+        req_category = request.args.get("category", "")
+        initial_values = {
+            "category": req_category if req_category in self.categories else "",
+            "subject": request.args.get("subject", ""),
+            "description": request.args.get("description", ""),
+        }
+        if blocked_ref:
+            initial_values.update(
+                {
+                    "subject": "Blocked access to Zenodo",
+                    "description": (
+                        "I believe my access to Zenodo was blocked by mistake.\n"
+                        "Please find below the details of the blocked request.\n"
+                        f"\nReference ID: {blocked_ref}\n"
+                        "\nAdditional context:\n"
+                    ),
+                }
+            )
+
         return render_template(
             self.template,
             categories=self.categories,
             system_info=system_info,
+            initial_values=initial_values,
+            hide_login=hide_login,
         )
 
     def post(self):

--- a/site/zenodo_rdm/templates/semantic-ui/zenodo_rdm/support.html
+++ b/site/zenodo_rdm/templates/semantic-ui/zenodo_rdm/support.html
@@ -98,7 +98,7 @@
         <div class="row">
             <div class="sixteen wide mobile sixteen wide tablet ten wide computer column">
                 <h3>Contact us</h3>
-                {%- if not is_user_authenticated %}
+                {%- if not is_user_authenticated and not hide_login %}
                 <div class="ui clearing info message">
                     <div class="ui grid">
                         <div class="ui header sixteen wide column pb-0">Log in</div>
@@ -130,6 +130,7 @@
             data-description-min-length = '{{ config.SUPPORT_DESCRIPTION_MIN_LENGTH }}';
             data-description-max-length = '{{ config.SUPPORT_DESCRIPTION_MAX_LENGTH }}';
             data-api-endpoint = '{{ config.SUPPORT_ENDPOINT }}';
+            data-initial-values='{{ initial_values | tojson }}';
         >
         </div>
     {% endblock %}


### PR DESCRIPTION
> AI disclaimer: Claude Code helped with most of the JS, but I tried to correct overall naming and focus on driving this from the Python side mostly

* Bypass the referrer check when a valid nginx request ID is passed via the `?ref=` query param.
* Hide the login prompt for blocked users and pre-fill the form with the reference ID.
* Support pre-filling form fields (category, subject, description) via query params and server-side `initial_values`.