### PR TITLE
Update quota increase support category and fix some form state bugs

### DIFF
--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/CategoryDropdown.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/CategoryDropdown.js
@@ -3,14 +3,6 @@ import { PropTypes } from "prop-types";
 import { SelectField } from "react-invenio-forms";
 
 class CategoryDropdown extends Component {
-  constructor(props) {
-    super(props);
-
-    const { categories, defaultCategory, onCategoryChange } = props;
-    const activeCategory = categories?.find((el) => el.key === defaultCategory);
-    onCategoryChange(activeCategory);
-  }
-
   serializeCategory(category) {
     if (!category) {
       return null;
@@ -56,16 +48,14 @@ class CategoryDropdown extends Component {
 
 CategoryDropdown.propTypes = {
   categories: PropTypes.array,
-  defaultCategory: PropTypes.string,
-  activeCategory: PropTypes.string,
+  activeCategory: PropTypes.object,
   onCategoryChange: PropTypes.func,
   className: PropTypes.string,
 };
 
 CategoryDropdown.defaultProps = {
   categories: [],
-  defaultCategory: "",
-  activeCategory: "",
+  activeCategory: null,
   onCategoryChange: null,
   className: "",
 };

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/FileUploader.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/FileUploader.js
@@ -13,12 +13,17 @@ const FileUploader = ({
   handleDelete,
   errorMessage,
   rejectedFiles,
+  disabled,
 }) => {
   return (
     <div>
-      <Dropzone {...dropzoneParams}>
+      <Dropzone {...dropzoneParams} disabled={disabled}>
         {({ getRootProps, getInputProps }) => (
-          <div id="file-dropzone" {...getRootProps({ className: "dropzone" })}>
+          <div
+            id="file-dropzone"
+            {...getRootProps({ className: "dropzone" })}
+            style={disabled ? { opacity: 0.5, cursor: "not-allowed" } : undefined}
+          >
             <input {...getInputProps()} name={name} />
             <p className="ui medium header text-align-center m-0">
               Drag files here, or click to select files
@@ -56,11 +61,13 @@ FileUploader.propTypes = {
   errorMessage: PropTypes.string,
   rejectedFiles: PropTypes.array,
   handleDelete: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
 };
 
 FileUploader.defaultProps = {
   errorMessage: null,
   rejectedFiles: [],
+  disabled: false,
 };
 
 export default FileUploader;

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/SupportForm.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/SupportForm.js
@@ -241,7 +241,6 @@ class SupportForm extends Component {
               />
               <CategoryDropdown
                 categories={categories}
-                defaultCategory=""
                 activeCategory={activeCategory}
                 onCategoryChange={this.onCategoryChange}
                 className="eight wide field flex"

--- a/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/SupportForm.js
+++ b/site/zenodo_rdm/assets/semantic-ui/js/zenodo_rdm/src/support/components/SupportForm.js
@@ -276,6 +276,7 @@ class SupportForm extends Component {
                   }}
                   errorMessage={fileErrorMessage}
                   rejectedFiles={rejectedFiles}
+                  disabled={formDisabledForCategory}
                 />
               </div>
 
@@ -288,6 +289,8 @@ class SupportForm extends Component {
                     onLabel="Include browser and system information to assist us with narrowing down the cause of your problem."
                     offValue={false}
                     onValue
+                    disabled={formDisabledForCategory}
+                    optimized={false}
                   />
                   <label className="helptext">{sysInfo}</label>
                 </div>

--- a/site/zenodo_rdm/config.py
+++ b/site/zenodo_rdm/config.py
@@ -87,11 +87,14 @@ SUPPORT_ISSUE_CATEGORIES = [
     },
     {
         "key": "quota-increase",
-        "title": "Quota increase",
+        "title": "Storage quota increase",
         "description": (
-            "<p>We exceptionally grant a <strong>one-time quota increase up to 200GB</strong>. Requests beyond the 200GB are declined. Zenodo allows maximum 100 files in a record (this limit cannot be increased).</p>"
-            '<p><strong>Before you send the request</strong>, please follow the actions described on <a href="https://help.zenodo.org/docs/deposit/manage-files/quota-increase/">https://help.zenodo.org/docs/deposit/manage-files/quota-increase/</a>.</p>'
+            '<div class="ui warning visible message">'
+            '<div class="header">Increasing your storage quota</div>'
+            '<p>Follow the <a href="https://help.zenodo.org/docs/deposit/manage-quota/">storage quota guide</a> to manage the storage quota of your drafts.</p>'
+            "</div>"
         ),
+        "form_disabled": True,
     },
     {
         "key": "security-report",


### PR DESCRIPTION
- **fix(support): properly handle category selection side-effects**
  

- **fix(support): disable all applicable fields on state updates**
  * Disables the files upload/dropzone and browser info toggle for
    disabled categories.
  * Fixes an issue where when a category is selected from the querystring,
    the form wouldn't be disabled (if needed) and any warning messages
    were not displayed.
  

- **fix(support): update storage quota category**
  