### PR TITLE
stats fixes

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -205,8 +205,6 @@ APP_DEFAULT_SECURE_HEADERS = {
 
 # Remove file integrity checks
 CELERY_BEAT_SCHEDULE.pop("file-integrity-report", None)
-# Schedule record stats indexing every 6 hours (instead of every 10 minutes)
-CELERY_BEAT_SCHEDULE["reindex-stats"]["schedule"] = timedelta(hours=6)
 CELERY_BEAT_SCHEDULE = {
     **CELERY_BEAT_SCHEDULE,
     "metrics-calculate": {
@@ -228,13 +226,6 @@ CELERY_BEAT_SCHEDULE = {
         "task": "zenodo_rdm.openaire.tasks.retry_openaire_failures",
         "schedule": crontab(minute=0, hour=9),  # Every day at 09:00 UTC
     },
-    "stats-export": {
-        "task": "zenodo_rdm.stats.tasks.export_stats",
-        "schedule": crontab(minute=0, hour=4),
-        "kwargs": {
-            "retry": True,
-        },
-    },
     "cleanup-swh-depositions": {
         "task": "invenio_swh.tasks.cleanup_depositions",
         "schedule": crontab(minute=0, hour=6),  # Every day at 06:00 UTC
@@ -254,6 +245,31 @@ CELERY_BEAT_SCHEDULE = {
         "task": "invenio_collections.tasks.update_collections_size",
         "schedule": timedelta(hours=1),  # Every hour
     },
+}
+
+# Stats-related scheduled tasks
+# -----------------------------
+# Reindex record stats every 6 hours (instead of the upstream every-10-minutes default).
+CELERY_BEAT_SCHEDULE["reindex-stats"]["schedule"] = timedelta(hours=6)
+# Split the combined stats aggregation task into two independent tasks so that
+# a failure on one aggregation type doesn't prevent the other from running.
+# Both run every 2 hours, on the hour (00:00, 02:00, 04:00, ...).
+CELERY_BEAT_SCHEDULE.pop("stats-aggregate-events", None)
+CELERY_BEAT_SCHEDULE["stats-aggregate-record-views"] = {
+    "task": "invenio_stats.tasks.aggregate_events",
+    "args": [("record-view-agg",)],
+    "schedule": crontab(minute=0, hour="*/2"),
+}
+CELERY_BEAT_SCHEDULE["stats-aggregate-file-downloads"] = {
+    "task": "invenio_stats.tasks.aggregate_events",
+    "args": [("file-download-agg",)],
+    "schedule": crontab(minute=0, hour="*/2"),
+}
+# Export stats events to OpenAIRE's Matomo tracker, daily at 04:00 UTC.
+CELERY_BEAT_SCHEDULE["stats-export"] = {
+    "task": "zenodo_rdm.stats.tasks.export_stats",
+    "schedule": crontab(minute=0, hour=4),
+    "kwargs": {"retry": True},
 }
 
 if not IS_LOCAL_DEV:

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -675,7 +675,7 @@ RDM_SEARCH_USER_COMMUNITIES = {
 RDM_FACETS = {**RDM_FACETS, **CUSTOM_FIELDS_FACETS}
 RDM_FACETS["publication_date"]["facet"].post_filter = False
 RDM_FACETS["publication_date"]["facet"]._hard_bounds = {
-    "min": "1970",
+    "min": "2000",
     "max": "now/y",
 }
 


### PR DESCRIPTION
- **fix(config): set publication year facet default min to 2000**
  

- **fix(stats): split aggregations processing tasks**
  * Calculate views and downloads aggregations in separate tasks.
  * Switch to running the aggregations processing every 2 hours (instead
    of hourly).
  