### PR TITLE
feat(github): release handling support helpers

### DIFF
--- a/site/zenodo_rdm/github/release.py
+++ b/site/zenodo_rdm/github/release.py
@@ -3,7 +3,9 @@
 """Zenodo-RDM release class."""
 
 import json
+from functools import cached_property
 
+import github3
 from flask import current_app
 from invenio_github.errors import CustomGitHubMetadataError
 from invenio_rdm_records.services.github.metadata import RDMReleaseMetadata
@@ -21,11 +23,17 @@ class ZenodoReleaseMetadata(RDMReleaseMetadata):
         """Get extra metadata for ZenodoRDM."""
         zenodo_json_file_name = ".zenodo.json"
         try:
-            content = self.rdm_release.retrieve_remote_file(zenodo_json_file_name)
-            if not content:
-                # File does not exists
+            override = self.rdm_release.zenodo_json_override
+            if override is not None:
+                file_data = dict(override)
+            elif self.rdm_release.skip_zenodo_json:
                 return {}
-            file_data = json.loads(content.decoded.decode("utf-8"))
+            else:
+                content = self.rdm_release.retrieve_remote_file(zenodo_json_file_name)
+                if not content:
+                    # File does not exists
+                    return {}
+                file_data = json.loads(content.decoded.decode("utf-8"))
             if not file_data.get("license") and self.repo_license:
                 file_data.update({"license": self.repo_license})
             legacy_data = {"metadata": file_data}
@@ -36,6 +44,12 @@ class ZenodoReleaseMetadata(RDMReleaseMetadata):
             raise CustomGitHubMetadataError(
                 file=zenodo_json_file_name, message="Extra metadata load failed."
             )
+
+    def load_citation_file(self, citation_file_name):
+        """Return the citation file data, or None if it should be skipped."""
+        if self.rdm_release.skip_citation_cff:
+            return None
+        return super().load_citation_file(citation_file_name)
 
     def load_citation_metadata(self, data):
         """Load citation metadata for Zenodo using legacy->RDM serialization.
@@ -67,9 +81,42 @@ class ZenodoGithubRelease(RDMGithubRelease):
     """Zenodo Github release class.
 
     This class adds Zenodo specific metadata.
+
+    Recipe-style overrides (set on an instance before calling ``process_release``)
+    let support staff publish releases that would otherwise fail. See the
+    "GitHub" section of the support recipes for usage.
     """
 
     metadata_cls = ZenodoReleaseMetadata
+
+    #: Use this dict as ``.zenodo.json`` content instead of fetching from GitHub.
+    zenodo_json_override = None
+    #: Fetch metadata files from the repo's default branch instead of the tag.
+    metadata_from_head = False
+    #: Skip ``.zenodo.json`` entirely (fall through to CITATION.cff or defaults).
+    skip_zenodo_json = False
+    #: Skip ``CITATION.cff`` entirely.
+    skip_citation_cff = False
+
+    @cached_property
+    def _default_branch(self):
+        """Resolve the repository's default branch via the GitHub API."""
+        owner = self.repository_payload["owner"]["login"]
+        name = self.repository_payload["name"]
+        return self.gh.api.repository(owner, name).default_branch
+
+    def retrieve_remote_file(self, file_name):
+        """Retrieve a remote file, honoring ``metadata_from_head``."""
+        if not self.metadata_from_head:
+            return super().retrieve_remote_file(file_name)
+        owner = self.repository_payload["owner"]["login"]
+        name = self.repository_payload["name"]
+        try:
+            return self.gh.api.repository(owner, name).file_contents(
+                path=file_name, ref=self._default_branch
+            )
+        except github3.exceptions.NotFoundError:
+            return None
 
     @property
     def metadata(self):
@@ -80,7 +127,7 @@ class ZenodoGithubRelease(RDMGithubRelease):
 
         # If `.zenodo.json` is there use it
         if extra_metadata:
-            output.update(metadata.extra_metadata)
+            output.update(extra_metadata)
         # If not check for `CITATION.cff` and use
         else:
             citation_metadata = metadata.citation_metadata


### PR DESCRIPTION
These are not affecting the default GitHub releases publishing behavior, but are particularly handy for re-triggering releases that failed because of metadata issues from `.zenodo.json`, `CITATION.cff`, failed community checks (e.g. missing EU funding).

See docs PR at https://gitlab.cern.ch/digital-repositories/internal-docs/-/merge_requests/235