### PR TITLE
release

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -492,6 +492,9 @@ SEARCH_INDEX_PREFIX = "zenodo-"
 
 # Invenio-Stats
 # ==============
+# Don't count file downloads triggered by the previewer as download stats.
+RDM_STATS_EXCLUDE_PREVIEW_FILE_DOWNLOAD_EVENTS = True
+
 # Use a dedicated search client for stats aggregations with a higher timeout.
 from zenodo_rdm.stats.proxies import current_stats_search_client
 

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -102,7 +102,7 @@ from zenodo_rdm.subcommunities import (
     ZenodoSubCommunityRequest,
     ZenodoSubcommunityRequestSchema,
 )
-from zenodo_rdm.theme.views import frontpage_view_function
+from zenodo_rdm.theme.views import index as frontpage_view
 from zenodo_rdm.tokens import RATSubjectSchema
 
 # Flask
@@ -116,7 +116,7 @@ SECRET_KEY = "CHANGE_ME"
 # route correct hosts to the application.
 TRUSTED_HOSTS = ["0.0.0.0", "localhost", "127.0.0.1"]
 
-APP_RDM_ROUTES["index"] = ("/", frontpage_view_function)
+APP_RDM_ROUTES["index"] = ("/", frontpage_view)
 RDM_COMMUNITIES_ROUTES["community-home"] = (
     "/communities/<pid_value>/",
     communities_home,
@@ -998,7 +998,7 @@ RATELIMIT_PER_ENDPOINT = {
     "security.forgot_password": "10 per minute",
     "security.reset_password": "10 per minute",
     # Front page
-    "invenio_app_rdm.frontpage_view_function": "10 per second",
+    "invenio_app_rdm.index": "10 per second",
     # Records
     "invenio_app_rdm_records.record_thumbnail": "20 per second",
     "records.search": "30 per minute",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zenodo-rdm-app"
-version = "24.4.0"
+version = "24.4.1"
 authors = [
     { name = "CERN" }
 ]

--- a/site/zenodo_rdm/theme/views.py
+++ b/site/zenodo_rdm/theme/views.py
@@ -9,7 +9,7 @@ from .api import featured_communities, recent_uploads
 from .filters import is_blr_related_record, is_verified_community, is_verified_record
 
 
-def frontpage_view_function():
+def index():
     """Zenodo frontpage view."""
     return render_template(
         current_app.config["THEME_FRONTPAGE_TEMPLATE"],

--- a/uv.lock
+++ b/uv.lock
@@ -8406,7 +8406,7 @@ source = { editable = "site" }
 
 [[package]]
 name = "zenodo-rdm-app"
-version = "24.4.0"
+version = "24.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "github3-py" },


### PR DESCRIPTION
- **fix(frontpage): rename frontpage view function to match upstream references**
  Upstream templates use `invenio_app_rdm.index` when generating links to
  the frontpage via `(invenio_)url_for`.
  

- **fix(config): disable capturing download stats coming from previewer**
  

- **release: v24.4.1**
  