### PR TITLE
template: communities: fix missing title

### DIFF
--- a/templates/semantic-ui/invenio_communities/frontpage.html
+++ b/templates/semantic-ui/invenio_communities/frontpage.html
@@ -6,6 +6,8 @@
 
 {% extends "invenio_communities/base.html" %}
 
+{%- set title = _("Communities") -%}
+
 {%- block javascript %}
   {{ super() }}
   {{ webpack['invenio-communities-frontpage.js'] }}


### PR DESCRIPTION
Discovered that the About and Curation policy pages had missing titles when testing inveniosoftware/invenio-theme#279

The [default template in invenio-communities](https://github.com/inveniosoftware/invenio-communities/blob/master/invenio_communities/templates/semantic-ui/invenio_communities/frontpage.html) properly defines a title, but the template in Zenodo does not.