### PR TITLE
fix(openaire): don't retry records OpenAIRE rejects as too large

### DIFF
--- a/site/tests/openaire/test_tasks.py
+++ b/site/tests/openaire/test_tasks.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Test OpenAIRE tasks."""
 
-from unittest.mock import call
+from unittest.mock import MagicMock, call
 
+import pytest
 from invenio_cache.proxies import current_cache
 
 from zenodo_rdm.openaire.tasks import (
@@ -126,6 +127,19 @@ def test_openaire_retries_task(
     assert mocked_session.post.called_once()
 
     # Assert cache does not have the key
+    assert not current_cache.cache.has(f"openaire_direct_index:{openaire_record.id}")
+
+
+@pytest.mark.parametrize("status_code", [400, 413])
+def test_openaire_direct_index_rejected(
+    status_code, running_app, openaire_record, mocked_session, enable_openaire_indexing
+):
+    """A 400/413 from OpenAIRE is terminal, so the record is neither retried nor cached."""
+    rejected = MagicMock(ok=False, status_code=status_code, text="Rejected")
+    mocked_session.post = MagicMock(return_value=rejected)
+
+    openaire_direct_index.delay(openaire_record.id)
+
     assert not current_cache.cache.has(f"openaire_direct_index:{openaire_record.id}")
 
 

--- a/site/zenodo_rdm/openaire/errors.py
+++ b/site/zenodo_rdm/openaire/errors.py
@@ -5,3 +5,18 @@
 
 class OpenAIRERequestError(Exception):
     """Error for failed requests on the OpenAIRE API."""
+
+
+class OpenAIREInvalidRecordError(OpenAIRERequestError):
+    """Record deterministically rejected by the OpenAIRE Direct Indexing API.
+
+    OpenAIRE validates submitted records and rejects invalid ones with HTTP 400
+    (missing mandatory fields) or 413 (overall body or per-field size limits).
+    These rejections are deterministic, so retrying the same record never
+    succeeds. The response body names the offending field and the limit.
+    """
+
+    def __init__(self, status_code, message):
+        """Keep the status code so callers can tell 400 from 413."""
+        self.status_code = status_code
+        super().__init__(message)

--- a/site/zenodo_rdm/openaire/tasks.py
+++ b/site/zenodo_rdm/openaire/tasks.py
@@ -12,7 +12,7 @@ from invenio_cache import current_cache
 from invenio_rdm_records.proxies import current_rdm_records_service as records_service
 from werkzeug.local import LocalProxy
 
-from .errors import OpenAIRERequestError
+from .errors import OpenAIREInvalidRecordError, OpenAIRERequestError
 from .serializers import OpenAIREV1Serializer
 from .utils import get_openaire_id, openaire_request_factory, openaire_type
 
@@ -66,8 +66,12 @@ def openaire_direct_index(record_id, retry=True):
         session = openaire_request_factory()
         res = session.post(url, json=serialized_record, timeout=30)
 
+        # 400/413 are deterministic rejections, retrying never succeeds.
+        if res.status_code in (400, 413):
+            raise OpenAIREInvalidRecordError(res.status_code, res.text)
+
         if not res.ok:
-            raise OpenAIRERequestError(res.text)
+            raise OpenAIRERequestError(f"HTTP {res.status_code}: {res.text}")
 
         beta_base_url = current_app.config.get("OPENAIRE_API_URL_BETA")
         if beta_base_url:
@@ -75,15 +79,33 @@ def openaire_direct_index(record_id, retry=True):
             res_beta = session.post(beta_endpoint, json=serialized_record, timeout=30)
 
             if not res_beta.ok:
-                # Just log the error, but don't raise
-                current_app.logger.warning("OpenAIRE indexing to beta failed")
+                # Beta is best-effort, don't raise.
+                ctx = {"record_id": record_id, "status_code": res_beta.status_code}
+                current_app.logger.warning(
+                    "OpenAIRE beta indexing failed for record %(record_id)s (HTTP %(status_code)s).",
+                    ctx,
+                    extra=ctx,
+                )
 
         current_cache.delete(f"openaire_direct_index:{record_id}")
+    except OpenAIREInvalidRecordError as exc:
+        # Deterministic rejection: don't retry, drop from the failures cache.
+        current_cache.delete(f"openaire_direct_index:{record_id}")
+        ctx = {"record_id": record_id, "status_code": exc.status_code}
+        current_app.logger.warning(
+            "OpenAIRE rejected record %(record_id)s for direct indexing (HTTP %(status_code)s).",
+            ctx,
+            extra={**ctx, "openaire_response": str(exc)},
+        )
     except Exception as exc:
         current_cache.set(
             f"openaire_direct_index:{record_id}", datetime.now(), timeout=-1
         )
-        current_app.logger.exception("Openaire index failed.")
+        current_app.logger.exception(
+            "OpenAIRE direct indexing failed for record %(record_id)s.",
+            {"record_id": record_id},
+            extra={"record_id": record_id},
+        )
         if retry:
             openaire_direct_index.retry(exc=exc)
         else:
@@ -113,14 +135,19 @@ def openaire_delete(record_id=None, retry=True):
         res = session.delete(f"{base_url}/result/{openaire_id}")
 
         if not res.ok:
-            raise OpenAIRERequestError(res.text)
+            raise OpenAIRERequestError(f"HTTP {res.status_code}: {res.text}")
 
         base_beta_url = current_app.config.get("OPENAIRE_API_URL_BETA")
         if base_beta_url:
             res_beta = session.delete(f"{base_beta_url}/result/{openaire_id}")
             if not res_beta.ok:
-                # Just log the error, but don't raise
-                current_app.logger.warning("OpenAIRE deleting to beta failed")
+                # Beta is best-effort, don't raise.
+                ctx = {"record_id": record_id, "status_code": res_beta.status_code}
+                current_app.logger.warning(
+                    "OpenAIRE beta deletion failed for record %(record_id)s (HTTP %(status_code)s).",
+                    ctx,
+                    extra=ctx,
+                )
 
         # Remove from failures cache
         current_cache.delete(f"openaire_direct_index:{record_id}")
@@ -129,7 +156,11 @@ def openaire_delete(record_id=None, retry=True):
         current_cache.set(
             f"openaire_direct_index:{record_id}", datetime.now(), timeout=-1
         )
-        current_app.logger.exception("Openaire delete failed.")
+        current_app.logger.exception(
+            "OpenAIRE deletion failed for record %(record_id)s.",
+            {"record_id": record_id},
+            extra={"record_id": record_id},
+        )
         if retry:
             openaire_delete.retry(exc=exc)
         else:
@@ -159,5 +190,8 @@ def retry_openaire_failures():
             else:
                 openaire_direct_index.delay(record_id, retry=False)
         except Exception:
-            # Otherwise it stops processing records when the first one fails.
+            # Keep going if one record fails, but log so it stays visible.
+            current_app.logger.exception(
+                "Could not reschedule OpenAIRE retry for cached failure."
+            )
             continue


### PR DESCRIPTION
OpenAIRE will start rejecting oversized payloads on the Direct Indexing
API with HTTP 413. That rejection is deterministic, so retrying wastes
work and keeps the record stuck in the failures cache that
retry_openaire_failures sweeps.

We now treat 413 as a terminal outcome, dropping the record from the
failures cache and skipping the retry. We rely on the API to decide
what's too large rather than checking payload size locally, so a future
change to the limit needs no change here.
