### PR TITLE
Legacy REST API validation fixes

### DIFF
--- a/site/tests/legacy/deposits/test_rest_api_metadata.py
+++ b/site/tests/legacy/deposits/test_rest_api_metadata.py
@@ -150,6 +150,60 @@ def test_malformed_license(
     assert expected_message in errors[0]["messages"][0]
 
 
+@pytest.mark.parametrize(
+    "communities",
+    [
+        {"identifier": "my-community"},  # object instead of array
+        [{"id": "my-community"}],  # wrong key ("id" instead of "identifier")
+        ["my-community"],  # array of strings instead of objects
+    ],
+)
+def test_malformed_communities(
+    test_app, client_with_login, deposit_url, headers, communities
+):
+    """Communities must be an array of objects with an 'identifier' key."""
+    data = {
+        "metadata": {
+            "title": "Test",
+            "upload_type": "dataset",
+            "description": "Test description",
+            "creators": [{"name": "Test User"}],
+            "communities": communities,
+        }
+    }
+    res = client_with_login.post(deposit_url, json=data, headers=headers)
+    assert res.status_code == 400
+    errors = res.json["errors"]
+    assert errors[0]["field"] == "communities"
+    assert "identifier" in errors[0]["messages"][0]
+
+
+@pytest.mark.parametrize(
+    "communities",
+    [
+        [{"identifier": "c1"}],
+        [{"identifier": "c1"}, {"identifier": "c2"}],
+    ],
+)
+def test_valid_communities(
+    test_app, client_with_login, deposit_url, headers, communities
+):
+    """Valid communities: an array of objects with an 'identifier' key."""
+    data = {
+        "metadata": {
+            "title": "Test",
+            "upload_type": "dataset",
+            "description": "Test description",
+            "creators": [{"name": "Test User"}],
+            "communities": communities,
+        }
+    }
+    res = client_with_login.post(deposit_url, json=data, headers=headers)
+    assert res.status_code == 201
+    returned = {c["identifier"] for c in res.json["metadata"]["communities"]}
+    assert returned == {c["identifier"] for c in communities}
+
+
 @pytest.mark.parametrize("license_value", ["cc-by-4.0", {"id": "cc-by-4.0"}])
 def test_valid_license(
     test_app, client_with_login, deposit_url, headers, license_value

--- a/site/tests/legacy/test_grant_serialization.py
+++ b/site/tests/legacy/test_grant_serialization.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Test legacy serializer grant/funding dumping."""
+
+import pytest
+from marshmallow import missing
+
+from zenodo_rdm.legacy.serializers.schemas.zenodojson import MetadataSchema
+
+
+@pytest.mark.parametrize(
+    "funding",
+    [
+        [{"award": {"number": "101094817", "title": "Some award"}}],  # no funder
+        [{"funder": {"id": "00k4n6c32", "name": "EC"}}],  # no award
+    ],
+)
+def test_dump_grants_skips_incomplete_funding(test_app, funding):
+    """Funding missing a funder or award is skipped, not crashed (Sentry ZBDZ)."""
+    with test_app.app_context():
+        assert MetadataSchema().dump_grants({"funding": funding}) is missing
+
+
+def test_dump_grants_serializes_complete_funding(test_app):
+    """Funding with both award and funder produces a legacy grant."""
+    funding = [
+        {"award": {"number": "755021"}, "funder": {"id": "00k4n6c32", "name": "EC"}}
+    ]
+    with test_app.app_context():
+        grants = MetadataSchema().dump_grants({"funding": funding})
+    assert [g["code"] for g in grants] == ["755021"]

--- a/site/zenodo_rdm/legacy/deserializers/schemas.py
+++ b/site/zenodo_rdm/legacy/deserializers/schemas.py
@@ -210,6 +210,15 @@ class LegacySchema(Schema):
         communities = original.get("metadata", {}).get("communities", [])
 
         if communities:
+            is_array = isinstance(communities, list)
+            all_have_identifier = is_array and all(
+                isinstance(c, dict) and "identifier" in c for c in communities
+            )
+            if not all_have_identifier:
+                raise ValidationError(
+                    "Communities must be an array of objects with an 'identifier' key.",
+                    field_name="communities",
+                )
             community_ids = [c["identifier"] for c in communities]
             result.setdefault("custom_fields", {})
             result["custom_fields"].update({"legacy:communities": community_ids})

--- a/site/zenodo_rdm/legacy/serializers/schemas/common.py
+++ b/site/zenodo_rdm/legacy/serializers/schemas/common.py
@@ -284,8 +284,10 @@ class MetadataSchema(Schema):
 
     def _grant(self, award, funder):
         """Serialize an RDM award and funder into a legacy Zenodo grant."""
-        # RDM allows specifying only funder
-        if not award:
+        # RDM requires funder and makes award optional, but draft saves don't block
+        # on validation, so a draft can persist funding missing either part. Skip
+        # those instead of crashing when serializing the record.
+        if not award or not funder:
             return
         funder_id = funder.get("id")
         funder_id = FUNDER_ROR_TO_DOI.get(funder_id, funder_id)


### PR DESCRIPTION
- **fix(legacy): validate communities shape in deposit deserializer**
  load_communities assumed an array of {"identifier": ...} objects and raised
  unhandled TypeError/KeyError (HTTP 500) on other shapes seen in production: a
  bare object instead of an array, or objects keyed by "id". Enforce the
  documented contract with a ValidationError so non-conforming input returns 400.
  

- **fix(legacy): skip grant serialization when funder is missing**
  _grant only guarded against a missing award, so funding that carried an award but
  no funder raised AttributeError (HTTP 500) while serializing the legacy response —
  seen on records.create in 24.5.0. Skip such entries; a legacy grant needs both.
  