### PR TITLE
previewer: fix provide file to simple_image_preview template

### DIFF
--- a/site/zenodo_rdm/previewer/image_previewer.py
+++ b/site/zenodo_rdm/previewer/image_previewer.py
@@ -68,6 +68,9 @@ def preview(file):
                 return render_template(
                     "invenio_app_rdm/records/previewers/simple_image_preview.html",
                     css_bundles=["image-previewer.css"],
+                    # `file` is needed for `file.is_iframe` in `invenio_previewer/rdm_abstract_previewer.html`
+                    file=file,
+                    # `file_url` is needed in `invenio_app_rdm/records/previewers/simple_image_preview.html`
                     file_url=file.file.links["iiif_api"],
                 )
             # The image size is greater than configured size,
@@ -96,6 +99,9 @@ def preview(file):
                 return render_template(
                     "invenio_app_rdm/records/previewers/simple_image_preview.html",
                     css_bundles=["image-previewer.css"],
+                    # `file` is needed for `file.is_iframe` in `invenio_previewer/rdm_abstract_previewer.html`
+                    file=file,
+                    # `file_url` is needed in `invenio_app_rdm/records/previewers/simple_image_preview.html`
                     file_url=file.uri,
                 )
 


### PR DESCRIPTION
File which are still being processed fail to be previewed with the following exception:

```
  File "/path/zenodo-rdm/.venv/var/instance/templates/semantic-ui/invenio_app_rdm/records/previewers/simple_image_preview.html", line 5, in top-level template code
    {%- extends config.PREVIEWER_ABSTRACT_TEMPLATE %}
  File "/path/zenodo-rdm/.venv/lib/python3.9/site-packages/invenio_app_rdm/theme/templates/semantic-ui/invenio_previewer/rdm_abstract_previewer.html", line 10, in top-level template code
    {%- extends "invenio_previewer/base.html" %}
  File "/path/zenodo-rdm/.venv/lib/python3.9/site-packages/invenio_previewer/templates/semantic-ui/invenio_previewer/base.html", line 23, in top-level template code
    {% block page_body %}{% endblock %}
  File "/path/zenodo-rdm/.venv/lib/python3.9/site-packages/invenio_app_rdm/theme/templates/semantic-ui/invenio_previewer/rdm_abstract_previewer.html", line 23, in block 'page_body'
    {%- if not file.is_iframe %}
  File "/path/zenodo-rdm/.venv/lib/python3.9/site-packages/jinja2/environment.py", line 490, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'file' is undefined
```

This is due to the fact that [`rdm_abstract_previewer.html` is accessing `file.is_iframe`](https://github.com/inveniosoftware/invenio-app-rdm/blob/v14.0.0rc2/invenio_app_rdm/theme/templates/semantic-ui/invenio_previewer/rdm_abstract_previewer.html#L23).

This PR fixes this problem by providing `file` to the rendering of `simple_image_preview.html`