### PR TITLE
Legacy files REST API fixes

### DIFF
--- a/site/tests/legacy/test_files_operations.py
+++ b/site/tests/legacy/test_files_operations.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Test legacy REST API file operations on both endpoint variants.
+
+Covers ``/api/deposit/depositions/<id>/files`` (old-style deposit files API)
+and ``/api/files/<bucket_id>/<key>`` (Files-REST API).
+"""
+
+from io import BytesIO
+
+DEPOSIT_DATA = {
+    "metadata": {
+        "upload_type": "dataset",
+        "title": "Legacy files operations",
+        "creators": [{"name": "Doe, John"}],
+        "publication_date": "2020-01-01",
+        "description": "Legacy files operations test",
+        "access_right": "open",
+    }
+}
+
+
+def test_deposit_files_operations(client, deposit_url, headers, uploader):
+    """Upload, list, read and delete files via /api/deposit/depositions."""
+    client = uploader.api_login(client)
+    res = client.post(deposit_url, json=DEPOSIT_DATA, headers=headers)
+    assert res.status_code == 201, res.json
+    files_url = res.json["links"]["files"]
+
+    # Upload two files
+    res = client.post(
+        files_url,
+        data={"name": "one.txt", "file": (BytesIO(b"one"), "one.txt")},
+        content_type="multipart/form-data",
+    )
+    assert res.status_code == 201, res.json
+    file_one = res.json
+    assert file_one["filename"] == "one.txt"
+    assert file_one["filesize"] == 3
+    assert file_one["checksum"] == "f97c5d29941bfb1b2fdab0874906ab82"
+    assert {"self", "download"} <= file_one["links"].keys()
+
+    res = client.post(
+        files_url,
+        data={"name": "two.txt", "file": (BytesIO(b"two"), "two.txt")},
+        content_type="multipart/form-data",
+    )
+    assert res.status_code == 201, res.json
+    file_two = res.json
+
+    # List files
+    res = client.get(files_url, headers=headers)
+    assert res.status_code == 200
+    assert sorted(f["filename"] for f in res.json) == ["one.txt", "two.txt"]
+
+    # Read a single file
+    res = client.get(file_one["links"]["self"], headers=headers)
+    assert res.status_code == 200
+    assert res.json["id"] == file_one["id"]
+    assert res.json["filename"] == "one.txt"
+    assert res.json["checksum"] == "f97c5d29941bfb1b2fdab0874906ab82"
+
+    # Delete a file
+    res = client.delete(file_one["links"]["self"], headers=headers)
+    assert res.status_code == 204
+    assert res.data == b""
+
+    # Listing reflects the deletion
+    res = client.get(files_url, headers=headers)
+    assert res.status_code == 200
+    assert [f["filename"] for f in res.json] == ["two.txt"]
+    assert res.json[0]["id"] == file_two["id"]
+
+
+def test_files_rest_operations(client, deposit_url, headers, files_headers, uploader):
+    """Upload, list, download and delete files via /api/files/<bucket_id>."""
+    client = uploader.api_login(client)
+    res = client.post(deposit_url, json=DEPOSIT_DATA, headers=headers)
+    assert res.status_code == 201, res.json
+    bucket_url = res.json["links"]["bucket"]
+
+    # Upload a file
+    res = client.put(
+        f"{bucket_url}/data.txt",
+        headers=files_headers,
+        data=BytesIO(b"1, 2, 3"),
+    )
+    assert res.status_code == 201, res.json
+    data = res.json
+    assert {"created", "updated"} <= data.keys()
+    assert data["version_id"]
+    assert data["key"] == "data.txt"
+    assert data["size"] == 7
+    assert data["checksum"] == "md5:66ce05ea43c73b8e33c74c12d0371bc9"
+    assert data["mimetype"] == "text/plain"
+    assert data["is_head"] is True
+    assert data["delete_marker"] is False
+    assert {"self", "uploads", "version"} <= data["links"].keys()
+
+    # Download the file
+    res = client.get(f"{bucket_url}/data.txt")
+    assert res.status_code == 200
+    assert res.data == b"1, 2, 3"
+
+    # Overwrite the same key (delete + recreate under the hood)
+    res = client.put(
+        f"{bucket_url}/data.txt",
+        headers=files_headers,
+        data=BytesIO(b"4, 5, 6, 7"),
+    )
+    assert res.status_code == 201, res.json
+    assert res.json["size"] == 10
+    assert res.json["checksum"] == "md5:eaf1424a3bb9fafc4c7bb85c75806fd5"
+
+    res = client.get(f"{bucket_url}/data.txt")
+    assert res.status_code == 200
+    assert res.data == b"4, 5, 6, 7"

--- a/site/tests/legacy/test_files_operations.py
+++ b/site/tests/legacy/test_files_operations.py
@@ -65,6 +65,12 @@ def test_deposit_files_operations(client, deposit_url, headers, uploader):
     assert res.status_code == 204
     assert res.data == b""
 
+    # Reading and deleting it again is a 404
+    res = client.get(file_one["links"]["self"], headers=headers)
+    assert res.status_code == 404
+    res = client.delete(file_one["links"]["self"], headers=headers)
+    assert res.status_code == 404
+
     # Listing reflects the deletion
     res = client.get(files_url, headers=headers)
     assert res.status_code == 200
@@ -132,3 +138,9 @@ def test_files_rest_operations(client, deposit_url, headers, files_headers, uplo
     res = client.delete(f"{bucket_url}/data.txt", headers=headers)
     assert res.status_code == 204, res.text
     assert res.data == b""
+
+    # Downloading and deleting it again is a 404
+    res = client.get(f"{bucket_url}/data.txt")
+    assert res.status_code == 404
+    res = client.delete(f"{bucket_url}/data.txt", headers=headers)
+    assert res.status_code == 404

--- a/site/tests/legacy/test_files_operations.py
+++ b/site/tests/legacy/test_files_operations.py
@@ -115,3 +115,9 @@ def test_files_rest_operations(client, deposit_url, headers, files_headers, uplo
     res = client.get(f"{bucket_url}/data.txt")
     assert res.status_code == 200
     assert res.data == b"4, 5, 6, 7"
+
+    # Delete the file (regression: serializing the empty 204 body crashed
+    # with "TypeError: string indices must be integers")
+    res = client.delete(f"{bucket_url}/data.txt", headers=headers)
+    assert res.status_code == 204, res.text
+    assert res.data == b""

--- a/site/tests/legacy/test_files_operations.py
+++ b/site/tests/legacy/test_files_operations.py
@@ -116,6 +116,17 @@ def test_files_rest_operations(client, deposit_url, headers, files_headers, uplo
     assert res.status_code == 200
     assert res.data == b"4, 5, 6, 7"
 
+    # List files in the bucket (Files-REST style "contents" envelope)
+    res = client.get(bucket_url, headers=headers)
+    assert res.status_code == 200, res.text
+    contents = res.json["contents"]
+    assert len(contents) == 1
+    assert contents[0]["key"] == "data.txt"
+    assert contents[0]["size"] == 10
+    assert contents[0]["checksum"] == "md5:eaf1424a3bb9fafc4c7bb85c75806fd5"
+    assert contents[0]["is_head"] is True
+    assert {"self", "uploads", "version"} <= contents[0]["links"].keys()
+
     # Delete the file (regression: serializing the empty 204 body crashed
     # with "TypeError: string indices must be integers")
     res = client.delete(f"{bucket_url}/data.txt", headers=headers)

--- a/site/zenodo_rdm/legacy/resources.py
+++ b/site/zenodo_rdm/legacy/resources.py
@@ -352,7 +352,6 @@ class LegacyFilesRESTResource(FileResource):
         return commit_file_result.to_dict(), 201
 
     @request_files_view_args
-    @response_handler()
     def delete_object(self):
         """Delete a file as in Files-REST views."""
         bucket_id = resource_requestctx.view_args["bucket_id"]

--- a/site/zenodo_rdm/legacy/serializers/__init__.py
+++ b/site/zenodo_rdm/legacy/serializers/__init__.py
@@ -8,6 +8,7 @@ from marshmallow import fields, missing, post_dump
 from .schemas import (
     LegacyFileListSchema,
     LegacyFileSchema,
+    LegacyFilesRESTListSchema,
     LegacyFilesRESTSchema,
     LegacySchema,
     ZenodoSchema,
@@ -78,5 +79,5 @@ class LegacyFilesRESTJSONSerializer(MarshmallowSerializer):
         super().__init__(
             format_serializer_cls=JSONSerializer,
             object_schema_cls=LegacyFilesRESTSchema,
-            list_schema_cls=BaseListSchema,
+            list_schema_cls=LegacyFilesRESTListSchema,
         )

--- a/site/zenodo_rdm/legacy/serializers/schemas/__init__.py
+++ b/site/zenodo_rdm/legacy/serializers/schemas/__init__.py
@@ -2,13 +2,19 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Zenodo legacy services."""
 
-from .files import LegacyFileListSchema, LegacyFileSchema, LegacyFilesRESTSchema
+from .files import (
+    LegacyFileListSchema,
+    LegacyFileSchema,
+    LegacyFilesRESTListSchema,
+    LegacyFilesRESTSchema,
+)
 from .legacyjson import LegacySchema
 from .zenodojson import ZenodoSchema
 
 __all__ = (
     "LegacyFileListSchema",
     "LegacyFileSchema",
+    "LegacyFilesRESTListSchema",
     "LegacyFilesRESTSchema",
     "LegacySchema",
     "ZenodoSchema",

--- a/site/zenodo_rdm/legacy/serializers/schemas/files.py
+++ b/site/zenodo_rdm/legacy/serializers/schemas/files.py
@@ -50,6 +50,27 @@ class LegacyFilesRESTSchema(Schema):
         }
 
 
+class LegacyFilesRESTListSchema(Schema):
+    """Files-REST bucket listing schema."""
+
+    entries = fields.List(fields.Nested(LegacyFilesRESTSchema), dump_only=True)
+
+    def __init__(self, object_schema_cls=None, **kwargs):
+        """
+        Initialize the schema.
+
+        The object_schema_cls parameter is accepted (and ignored) for
+        compatibility with MarshmallowSerializer which always passes it
+        when instantiating list schemas (we hardcode the schema in entries).
+        """
+        super().__init__(**kwargs)
+
+    @post_dump()
+    def wrap(self, data, many, **kwargs):
+        """Wrap entries in a Files-REST style envelope."""
+        return {"contents": data.get("entries", [])}
+
+
 class LegacyFileListSchema(Schema):
     """Files list schema."""
 

--- a/site/zenodo_rdm/legacy/services.py
+++ b/site/zenodo_rdm/legacy/services.py
@@ -367,6 +367,12 @@ class LegacyFileService(FileService):
             )
             permission_action_prefix = ""
 
+        # Check file existence before permissions (as upstream does), since
+        # file-conditional generators (e.g. IfTransferType) deny on a missing
+        # file and would turn a 404 into a 403.
+        if file_key and file_key not in record.files:
+            raise FileKeyNotFoundError(id_, file_key)
+
         self.require_permission(
             identity,
             action,
@@ -375,9 +381,6 @@ class LegacyFileService(FileService):
             permission_action_prefix=permission_action_prefix,
             **kwargs,
         )
-
-        if file_key and file_key not in record.files:
-            raise FileKeyNotFoundError(id_, file_key)
 
         return record
 
@@ -409,6 +412,8 @@ class LegacyFileService(FileService):
                 )
                 .filter(
                     FileInstance.id == file_id,
+                    # Soft-deleted files leave behind non-head object versions
+                    ObjectVersion.is_head.is_(True),
                     PersistentIdentifier.pid_type == "recid",
                     PersistentIdentifier.pid_value == pid_value,
                     PersistentIdentifier.object_type == "rec",


### PR DESCRIPTION
- **tests(legacy): cover files REST API operations on both variants**
  Baseline coverage for file upload, listing, reading, download and
  deletion via the old-style deposit files API
  (/api/deposit/depositions/<id>/files) and the Files-REST API
  (/api/files/<bucket_id>/<key>).
  

- **tests(legacy): replicate 500 on Files-REST file deletion**
  DELETE /api/files/<bucket_id>/<key> returns 500 because the empty 204
  body is passed through the Files-REST serializer, which fails with
  "TypeError: string indices must be integers". The file is still
  deleted, so clients get an error for an operation that succeeded. Fixed
  in the next commit.
  

- **fix(legacy): 500 on Files-REST file deletion**
  The 204 response of DELETE /api/files/<bucket_id>/<key> has no body,
  but @response_handler() only skips serialization for None, so the empty
  string was pushed through LegacyFilesRESTSchema and crashed on
  obj["links"]. Drop the decorator, matching upstream
  FileResource.delete and the deposit files variant.
  

- **tests(legacy): replicate 500 on Files-REST bucket listing**
  GET /api/files/<bucket_id> returns 500 because the serializer's
  BaseListSchema expects a search result shape (hits.hits) while the view
  returns a files list (entries), crashing with KeyError: 'hits'. Expects
  the invenio-files-rest style {"contents": [...]} envelope that legacy
  Zenodo returned. Fixed in the next commit.
  

- **fix(legacy): 500 on Files-REST bucket listing serialization**
  GET /api/files/<bucket_id> serialized the files list with
  BaseListSchema, which expects a search result (hits.hits) and crashed
  with KeyError: 'hits'. Add LegacyFilesRESTListSchema that wraps the
  entries in the {"contents": [...]} envelope legacy Zenodo's
  invenio-files-rest returned.
  

- **tests(legacy): replicate 403 on reads of deleted files**
  Reading (or re-deleting) an already deleted file returns 403 instead of
  404 on both API variants:
  
  * /api/deposit/depositions/<id>/files/<file_id> still resolves the file
    key from the soft-deleted (non-head) object version, and the
    file-conditional permission generators then deny access.
  * /api/files/<bucket_id>/<key> checks permissions before file existence,
    so the same generators deny before the 404 can be raised.
  
  Fixed in the next commit.
  

- **fix(legacy): return 404 instead of 403 for deleted files**
  Two causes, one per API variant:
  
  * get_file_key_by_id matched soft-deleted files, since deletion leaves
    behind a non-head object version. Only match head versions, so
    deleted file IDs no longer resolve.
  * LegacyFileService._get_record checked permissions before file
    existence. File-conditional permission generators (e.g.
    IfTransferType) deny on a missing file, turning would-be 404s into
    403s. Check existence first, as upstream FileService._get_record
    does.
  