### PR TITLE
fix(ui): render login hint correctly for restricted files

### DIFF
--- a/templates/semantic-ui/zenodo_rdm/records/detail.html
+++ b/templates/semantic-ui/zenodo_rdm/records/detail.html
@@ -52,7 +52,7 @@
             <div class="ui {{ record.ui.access_status.message_class }} message file-box-message rel-pl-1 rel-pr-1">
               <i class="ui {{ record.ui.access_status.icon }} icon" aria-hidden="true"></i>
               <h4 class="inline">{{ record.ui.access_status.title_l10n }}</h4>
-              <p>{{ record.ui.access_status.description_l10n }}</p>
+              <p>{{ record.ui.access_status.description_l10n | safe }}</p>
 
               {% if record.access.embargo.reason %}
                 <p>{{ _("Reason") }}: {{ record.access.embargo.reason }}</p>


### PR DESCRIPTION
The login hint (added in
https://github.com/inveniosoftware/invenio-rdm-records/commit/22a77bdfd1e449b6bc3bd24fcb2bb60bdade2c0f) for restricted files contains html tags that are not correctly displayed in Zenodo, since the html was being escaped. The template in Zenodo did not have `| safe`, as it was done in invenio-app-rdm.

Before:
<img width="882" height="269" alt="image" src="https://github.com/user-attachments/assets/773f64cb-ae61-43dd-a4b2-efa1f700b908" />

After:
<img width="883" height="235" alt="image" src="https://github.com/user-attachments/assets/8092c825-6e9c-4630-ae59-77aed917ca28" />
