### PR TITLE
fix(doi): correct concept doi related identifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   Python:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
           python-version: ["3.9"]
@@ -36,7 +36,7 @@ jobs:
       EXTRAS: tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cache Docker images
         # We're using the fork by AndreKurait, which has bumped the "cache" action
@@ -66,11 +66,12 @@ jobs:
         run: ./run-tests.sh
 
   JS:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-      - name: Use Node.js v16.x
+        uses: actions/checkout@v7
+
+      - name: Use Node.js v24.x
         uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ To update dependencies you need to:
 > ```bash
 > uv lock --upgrade-package <package-name>
 > ```
+
+## Tests
+
+Tests can be run by activating the `uv` virtual env first:
+
+```bash
+cd zenodo-rdm
+source .venv/bin/activate
+(zenodo-rdm-app)$ ./run-tests.sh
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ members = [
 dev = [
     "pdbpp>=0.11.7",
     "pytest-invenio>=3.0.0,<4.0.0",
+    "pytest-mock>=1.6.0",
 ]
 
 [project.optional-dependencies]

--- a/site/tests/conftest.py
+++ b/site/tests/conftest.py
@@ -40,6 +40,7 @@ from zenodo_rdm.legacy.requests.record_upgrade import LegacyRecordUpgrade
 from zenodo_rdm.permissions import ZenodoRDMRecordPermissionPolicy
 from zenodo_rdm.queryparser import ZENODO_LEGACY_SEARCH_MAP
 from zenodo_rdm.resources import record_serializers
+from zenodo_rdm.serializers import ZenodoDataciteJSONSerializer
 
 from .fake_datacite_client import FakeDataCiteClient
 
@@ -81,6 +82,7 @@ def app_config(app_config):
         providers.DataCitePIDProvider(
             "datacite",
             client=FakeDataCiteClient("datacite", config_prefix="DATACITE"),
+            serializer=ZenodoDataciteJSONSerializer(),
             label=("DOI"),
         ),
         # DOI provider for externally managed DOIs
@@ -94,6 +96,15 @@ def app_config(app_config):
         providers.OAIPIDProvider(
             "oai",
             label=("OAI ID"),
+        ),
+    ]
+    app_config["RDM_PARENT_PERSISTENT_IDENTIFIER_PROVIDERS"] = [
+        # DataCite DOI provider with fake client
+        providers.DataCitePIDProvider(
+            "datacite",
+            client=FakeDataCiteClient("datacite", config_prefix="DATACITE"),
+            serializer=ZenodoDataciteJSONSerializer(is_parent=True),
+            label=("DOI"),
         ),
     ]
     app_config["RDM_PERSISTENT_IDENTIFIERS"] = (

--- a/site/tests/test_queryparser.py
+++ b/site/tests/test_queryparser.py
@@ -102,6 +102,6 @@ def test_search_map_value_mappers(published_records):
         # Unknown slug resolves to `"None"` and matches nothing.
         ('communities:"does-not-exist"', []),
     ]:
-        assert _search_ids(query) == expected, (
-            f"Query {query!r} expected {expected} but got {_search_ids(query)}"
-        )
+        assert (
+            _search_ids(query) == expected
+        ), f"Query {query!r} expected {expected} but got {_search_ids(query)}"

--- a/site/tests/test_serializers.py
+++ b/site/tests/test_serializers.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Integration tests for serializers."""
+
+
+def test_datacite_serializer(app, publish_record, minimal_record, mocker):
+    """Test that DOI minting includes the parent DOI as a related identifier."""
+    base = dict(minimal_record, files={"enabled": False})
+    metadata = dict(
+        base,
+        metadata=dict(
+            base["metadata"],
+            resource_type={"id": "publication-dissertation"},
+            title="A thesis",
+        ),
+    )
+    title = metadata["metadata"]["title"]
+    first_name = metadata["metadata"]["creators"][0]["person_or_org"]["given_name"]
+
+    mocker.patch("tests.fake_datacite_client.FakeDataCiteRESTClient.public_doi")
+
+    record = publish_record(metadata)
+    record_pid = record._record.pid.pid_value
+    concept_pid = record._record.parent.pid.pid_value
+    record_doi = f"10.5281/zenodo.{record_pid}"
+    concept_doi = f"10.5281/zenodo.{concept_pid}"
+
+    config = app.config["RDM_PARENT_PERSISTENT_IDENTIFIER_PROVIDERS"]
+    public_doi_fn = config[0].client._api.public_doi
+    # # get the metadata value
+    assert public_doi_fn.call_count == 2
+    # the first call is for the record DOI
+    serialized_record = public_doi_fn.call_args_list[0].kwargs["metadata"]
+    # the second call is for the concept DOI
+    serialized_concept = public_doi_fn.call_args_list[1].kwargs["metadata"]
+
+    for record in [serialized_record, serialized_concept]:
+        assert record["titles"][0]["title"] == title
+        assert record["creators"][0]["givenName"] == first_name
+
+    assert serialized_record["doi"] == record_doi
+    assert len(serialized_record["relatedIdentifiers"]) == 1
+    first_related_identifier = serialized_record["relatedIdentifiers"][0]
+    # the record is a version of the concept DOI
+    assert first_related_identifier["relatedIdentifier"] == concept_doi
+    assert first_related_identifier["relationType"] == "IsVersionOf"
+    assert first_related_identifier["relatedIdentifierType"] == "DOI"
+
+    assert serialized_concept["doi"] == concept_doi
+    assert len(serialized_concept["relatedIdentifiers"]) == 1
+    first_related_identifier = serialized_concept["relatedIdentifiers"][0]
+    # the concept has version of records
+    assert first_related_identifier["relatedIdentifier"] == record_doi
+    assert first_related_identifier["relationType"] == "HasVersion"
+    assert first_related_identifier["relatedIdentifierType"] == "DOI"

--- a/site/zenodo_rdm/providers.py
+++ b/site/zenodo_rdm/providers.py
@@ -200,7 +200,7 @@ RDM_PARENT_PERSISTENT_IDENTIFIER_PROVIDERS = [
     rdm_providers.DataCitePIDProvider(
         "datacite",
         client=rdm_providers.DataCiteClient("datacite", config_prefix="DATACITE"),
-        serializer=ZenodoDataciteJSONSerializer(schema_context={"is_parent": True}),
+        serializer=ZenodoDataciteJSONSerializer(is_parent=True),
         label=_("Concept DOI"),
     ),
     LegacyParentDOIProvider("legacy", pid_type="doi"),

--- a/site/zenodo_rdm/serializers/datacite.py
+++ b/site/zenodo_rdm/serializers/datacite.py
@@ -37,13 +37,16 @@ class ZenodoDataciteSchema(DATACITE_SCHEMA):
 class ZenodoDataciteJSONSerializer(MarshmallowSerializer):
     """Zenodo Datacite serializer."""
 
-    def __init__(self, **options):
+    def __init__(self, is_parent=False, **options):
         """Instantiate serializer."""
         super().__init__(
             format_serializer_cls=JSONSerializer,
             object_schema_cls=ZenodoDataciteSchema,
             list_schema_cls=BaseListSchema,
-            schema_kwargs={"dumpers": [JournalDataciteDumper()]},  # Order matters
+            schema_kwargs={
+                "dumpers": [JournalDataciteDumper()],  # Order matters
+                "is_parent": is_parent,
+            },
             **options,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -6178,6 +6178,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "pytest-pycodestyle"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -8670,6 +8682,7 @@ xrootd = [
 dev = [
     { name = "pdbpp" },
     { name = "pytest-invenio" },
+    { name = "pytest-mock" },
 ]
 
 [package.metadata]
@@ -8700,6 +8713,7 @@ provides-extras = ["sentry", "xrootd"]
 dev = [
     { name = "pdbpp", specifier = ">=0.11.7" },
     { name = "pytest-invenio", specifier = ">=3.0.0,<4.0.0" },
+    { name = "pytest-mock", specifier = ">=1.6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
- the change to the DataCite JSON serializer parameter introduced with inveniosoftware/invenio-rdm-records/eaa4ba426a1a5f9ae192461105fb109183444b2a was not propagated to Zenodo, causing the error of minting the concept doi with the same related identifier as each record version