### PR TITLE
feat(checks): add hide_parent_checks to Check

### DIFF
--- a/site/zenodo_rdm/checks/funding.py
+++ b/site/zenodo_rdm/checks/funding.py
@@ -26,6 +26,7 @@ class FundingCheck(Check):
     sort_order = 30
     sync = False
     target_type = "record"
+    hide_parent_checks = True
 
     default_messages = {
         "title": "Record metadata should match grant description",


### PR DESCRIPTION
Set hide_parent_checks to True in FundingCheck to allow filtering out, in the UI, the funding check class if there are no check runs generated by a config associated to a specific community.