### PR TITLE
feat(checks): add community member link to check

### DIFF
--- a/site/pyproject.toml
+++ b/site/pyproject.toml
@@ -20,6 +20,7 @@ invenio_openaire = "zenodo_rdm.openaire.ext:OpenAIRE"
 zenodo_rdm_stats = "zenodo_rdm.stats.ext:ZenodoStats"
 zenodo_rdm_curation = "zenodo_rdm.curation.ext:ZenodoCuration"
 zenodo_rdm_exporter = "zenodo_rdm.exporter.ext:ZenodoExporter"
+zenodo_rdm_theme = "zenodo_rdm.theme.ext:ZenodoTheme"
 
 [project.entry-points."invenio_base.api_apps"]
 zenodo_rdm_legacy = "zenodo_rdm.legacy.ext:ZenodoLegacy"

--- a/site/zenodo_rdm/subcommunities/checks.py
+++ b/site/zenodo_rdm/subcommunities/checks.py
@@ -166,6 +166,7 @@ class CommunityMembershipCheck(Check):
             )
 
             user_data = {
+                "id": user.id,
                 "name": user_name,
                 "domain": user.domain,
                 "role": member.role.capitalize(),

--- a/site/zenodo_rdm/theme/ext.py
+++ b/site/zenodo_rdm/theme/ext.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""ZenodoRDM Theme module."""
+
+from invenio_administration.permissions import administration_permission
+
+
+class ZenodoTheme:
+    """Zenodo Theme extension."""
+
+    def __init__(self, app=None):
+        """Extension initialization."""
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Flask application initialization."""
+        app.extensions["zenodo-theme"] = self
+        app.jinja_env.globals["is_admin"] = administration_permission.can

--- a/templates/semantic-ui/invenio_checks/requests/subcommunity_member_tab.html
+++ b/templates/semantic-ui/invenio_checks/requests/subcommunity_member_tab.html
@@ -28,9 +28,20 @@ under the terms of the MIT License; see LICENSE file for more details.
             <div class="rel-pt-1 rel-pb-1">
               {% for value in check_result.value %}
                 <div class="ui {{ value.level }} small message">
-                  {% if value.name %}<strong>{{ value.name ~ " - " ~ value.role }}</strong>
+                  {% set is_self = current_user.is_authenticated and current_user.id == value.id %}
+                  {% if value.name %}
+                    <strong>
+                      {% if is_self %}
+                        <a href="{{ invenio_url_for('invenio_userprofiles.profile') }}">{{ value.name }}</a>
+                      {% elif is_admin() %}
+                        <a href="{{ invenio_url_for('administration.users', q='id:' ~ value.id) }}">{{ value.name }}</a>
+                      {% else %}
+                        {{ value.name }}
+                      {% endif %}
+                      {{ " - " ~ value.role }}
+                    </strong>
                   {% else %}
-                      <strong>{{ value.role }}</strong>
+                    <strong>{{ value.role }}</strong>
                   {% endif %}
                   <div class="text-muted">
                       {{ value.domain }}


### PR DESCRIPTION
User names in the subcommunity member check tab now link to either the profile settings page for the user, or to the administration user page for admins. Adds a ZenodoChecks Flask extension to expose administration_permission as a Jinja global.