### PR TITLE
Fix exporter error handling and logging

### DIFF
--- a/site/tests/exporter/test_writers.py
+++ b/site/tests/exporter/test_writers.py
@@ -67,3 +67,44 @@ def test_write_consumes_records_once_for_all_outputs(app, tmp_path):
     assert iterations == ["started"]
     assert _tar_members(paths[0]) == {}
     assert _tar_members(paths[1]) == {}
+
+
+def test_write_continues_after_record_errors(app, tmp_path, minimal_record, caplog):
+    """Malformed records do not stop other records or formats."""
+    invalid_xml = dict(
+        minimal_record,
+        id="invalid-xml",
+        metadata=dict(
+            minimal_record["metadata"],
+            funding=[
+                {
+                    "funder": {"name": "Test funder"},
+                    "award": {"title": {"en": "Invalid\x00title"}},
+                }
+            ],
+        ),
+    )
+    records = [
+        invalid_xml,
+        {
+            "id": "deleted",
+            "deletion_status": {"is_deleted": True},
+            "pids": {"doi": {"identifier": "10.5281/zenodo.1"}},
+            "parent": None,
+            "tombstone": None,
+        },
+        {"id": "after-error", "metadata": {"title": "Test"}},
+    ]
+
+    with app.app_context():
+        paths = write_archives(tmp_path, ("json", "xml"), records)
+
+    json_members = _tar_members(paths[0])
+    xml_members = _tar_members(paths[1])
+    assert set(json_members) == {"invalid-xml.json", "after-error.json"}
+    assert "invalid-xml.xml" not in xml_members
+    assert "Could not serialize record invalid-xml as xml" in caplog.text
+
+    with gzip.open(paths[2], mode="rt") as stream:
+        rows = list(csv.reader(stream))
+    assert rows[1][0:2] == ["deleted", "10.5281/zenodo.1"]

--- a/site/tests/exporter/test_writers.py
+++ b/site/tests/exporter/test_writers.py
@@ -32,7 +32,7 @@ def test_write_export_files(app, tmp_path):
     ]
 
     with app.app_context():
-        paths = write_archives(tmp_path, ("json",), records)
+        paths = write_archives(tmp_path, ("json",), records, len(records))
 
     assert [path.name for path in paths] == [
         "records-json.tar.gz",
@@ -62,7 +62,7 @@ def test_write_consumes_records_once_for_all_outputs(app, tmp_path):
         }
 
     with app.app_context():
-        paths = write_archives(tmp_path, ("json", "xml"), records())
+        paths = write_archives(tmp_path, ("json", "xml"), records(), 1)
 
     assert iterations == ["started"]
     assert _tar_members(paths[0]) == {}
@@ -97,7 +97,7 @@ def test_write_continues_after_record_errors(app, tmp_path, minimal_record, capl
     ]
 
     with app.app_context():
-        paths = write_archives(tmp_path, ("json", "xml"), records)
+        paths = write_archives(tmp_path, ("json", "xml"), records, len(records))
 
     json_members = _tar_members(paths[0])
     xml_members = _tar_members(paths[1])
@@ -108,3 +108,16 @@ def test_write_continues_after_record_errors(app, tmp_path, minimal_record, capl
     with gzip.open(paths[2], mode="rt") as stream:
         rows = list(csv.reader(stream))
     assert rows[1][0:2] == ["deleted", "10.5281/zenodo.1"]
+
+
+def test_write_logs_progress_and_rate(app, tmp_path, caplog):
+    """Progress logs include totals, throughput, and an ETA."""
+    records = ({"id": str(index)} for index in range(1000))
+    caplog.set_level("INFO")
+
+    with app.app_context():
+        write_archives(tmp_path, ("json",), records, 2000)
+
+    assert "Processed 1_000/2_000 records (50.0%) at" in caplog.text
+    assert "records/s; ETA" in caplog.text
+    assert "Exporter completed: processed 1_000/2_000 records" in caplog.text

--- a/site/zenodo_rdm/exporter/api.py
+++ b/site/zenodo_rdm/exporter/api.py
@@ -37,8 +37,8 @@ def export_records(formats, community_slug):
 
     with TemporaryDirectory(dir=staging_path) as run_path:
         # Read records once and write every requested format
-        record_stream = read_records(community_slug)
-        paths = write_archives(Path(run_path), formats, record_stream)
+        total, record_stream = read_records(community_slug)
+        paths = write_archives(Path(run_path), formats, record_stream, total)
 
         prefix = f"{community_slug}/" if community_slug else ""
         files = [(path, f"{prefix}{path.name}") for path in paths]

--- a/site/zenodo_rdm/exporter/api.py
+++ b/site/zenodo_rdm/exporter/api.py
@@ -47,9 +47,9 @@ def export_records(formats, community_slug):
         bucket_id = current_app.config["EXPORTER_BUCKET_UUID"]
         bucket = Bucket.get(bucket_id)
         if bucket:
-            current_app.logger.info(f"Exporter bucket found: {bucket_id}")
+            current_app.logger.info("Exporter bucket found: %s", bucket_id)
         else:
-            current_app.logger.info(f"Creating exporter bucket: {bucket_id}")
+            current_app.logger.info("Creating exporter bucket: %s", bucket_id)
             bucket = Bucket(
                 id=bucket_id,
                 default_location=Location.get_default().id,
@@ -73,7 +73,7 @@ def export_records(formats, community_slug):
                     key=key,
                     mimetype=EXPORT_MIMETYPE,
                 )
-                current_app.logger.info(f"Creating object version: {version}")
+                current_app.logger.info("Creating object version: %s", version)
                 with path.open("rb") as stream:
                     version.set_contents(stream, size=path.stat().st_size)
                 db.session.add(version)
@@ -93,7 +93,7 @@ def export_records(formats, community_slug):
                 )
                 for version in versions[keep:]:
                     current_app.logger.info(
-                        f"Removing previous object version: {version}"
+                        "Removing previous object version: %s", version
                     )
                     version.remove()
                 db.session.commit()

--- a/site/zenodo_rdm/exporter/readers.py
+++ b/site/zenodo_rdm/exporter/readers.py
@@ -11,7 +11,7 @@ from invenio_rdm_records.proxies import current_rdm_records_service
 
 
 def read_records(community_slug):
-    """Return a lazy stream of records to export."""
+    """Return the total and a lazy stream of records to export."""
     community_id = None
     if community_slug:
         community_id = (
@@ -29,18 +29,16 @@ def read_records(community_slug):
     records = current_rdm_records_service
     params = {"allversions": True, "include_deleted": True}
     records.require_permission(identity, "search")
-    result = (
-        records._search(
-            "scan",
-            identity,
-            params,
-            None,
-            q=f"parent.communities.ids:{community_id}" if community_id else "",
-        )
-        .params(scroll="15m")
-        .scan()
+    search = records._search(
+        "scan",
+        identity,
+        params,
+        None,
+        q=f"parent.communities.ids:{community_id}" if community_id else "",
     )
-    return records.result_list(
+    total = search[:0].extra(track_total_hits=True).execute().hits.total.value
+    result = search.params(scroll="15m").scan()
+    hits = records.result_list(
         records,
         identity,
         result,
@@ -50,3 +48,4 @@ def read_records(community_slug):
         expandable_fields=records.expandable_fields,
         expand=False,
     ).hits
+    return total, hits

--- a/site/zenodo_rdm/exporter/writers.py
+++ b/site/zenodo_rdm/exporter/writers.py
@@ -6,6 +6,7 @@ import csv
 import gzip
 import json
 import tarfile
+import time
 from collections.abc import Iterable, Mapping, Sequence
 from contextlib import ExitStack
 from io import BytesIO
@@ -47,10 +48,45 @@ SERIALIZERS = {
 EXPORT_FORMATS = tuple(SERIALIZERS)
 
 
+def _format_duration(seconds):
+    """Format a duration for progress logs."""
+    minutes, seconds = divmod(int(seconds), 60)
+    hours, minutes = divmod(minutes, 60)
+    days, hours = divmod(hours, 24)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {seconds}s"
+    return f"{seconds}s"
+
+
+def _log_progress(processed, total, started, errors, completed=False):
+    """Log export progress and throughput."""
+    elapsed = max(time.monotonic() - started, 1e-9)
+    rate = processed / elapsed
+    if completed:
+        current_app.logger.info(
+            f"Exporter completed: processed {processed:_}/{total:_} records in "
+            f"{_format_duration(elapsed)} at {rate:,.1f} records/s with {errors:_} errors"
+        )
+        return
+
+    percentage = processed / total * 100 if total else 100
+    remaining = max(total - processed, 0) / rate if rate else 0
+    current_app.logger.info(
+        f"Processed {processed:_}/{total:_} records ({percentage:.1f}%) at "
+        f"{rate:,.1f} records/s; ETA {_format_duration(remaining)}; "
+        f"errors: {errors:_}"
+    )
+
+
 def write_archives(
     run_path: Path,
     formats: Sequence[str],
     records: Iterable[Mapping],
+    total: int,
 ) -> list[Path]:
     """Write one set of records to all requested formats."""
     record_paths = {format: run_path / f"records-{format}.tar.gz" for format in formats}
@@ -75,10 +111,15 @@ def write_archives(
         deleted_writer = csv.writer(deleted)
         deleted_writer.writerow(DELETED_HEADER)
 
-        for index, record in enumerate(records):
-            if index % 1000 == 0:
-                current_app.logger.debug(f"Record index: {index:_}")
-            _write_record(record, formats, archives, deleted_writer)
+        started = time.monotonic()
+        processed = 0
+        errors = 0
+        for processed, record in enumerate(records, start=1):
+            errors += _write_record(record, formats, archives, deleted_writer)
+            if processed % 1000 == 0:
+                _log_progress(processed, total, started, errors)
+
+        _log_progress(processed, total, started, errors, completed=True)
 
     return [*record_paths.values(), deleted_path]
 
@@ -86,9 +127,10 @@ def write_archives(
 def _write_record(record, formats, archives, deleted_writer):
     record_id = record.get("id")
     if not record_id:
-        return
+        current_app.logger.error("Could not export record without an id")
+        return 1
 
-    if record.get("deletion_status", {}).get("is_deleted", False):
+    if (record.get("deletion_status") or {}).get("is_deleted", False):
         try:
             tombstone = record.get("tombstone") or {}
             removal_reason = (tombstone.get("removal_reason") or {}).get("id")
@@ -107,11 +149,12 @@ def _write_record(record, formats, archives, deleted_writer):
             current_app.logger.exception(
                 f"Could not export deleted record: {record_id}"
             )
-            return
+            return 1
 
         deleted_writer.writerow(row)
-        return
+        return 0
 
+    errors = 0
     for format in formats:
         try:
             content = SERIALIZERS[format](record)
@@ -119,8 +162,11 @@ def _write_record(record, formats, archives, deleted_writer):
             current_app.logger.exception(
                 f"Could not serialize record {record_id} as {format}"
             )
+            errors += 1
             continue
 
         info = tarfile.TarInfo(f"{record_id}.{format}")
         info.size = len(content)
         archives[format].addfile(info, fileobj=BytesIO(content))
+
+    return errors

--- a/site/zenodo_rdm/exporter/writers.py
+++ b/site/zenodo_rdm/exporter/writers.py
@@ -68,17 +68,26 @@ def _log_progress(processed, total, started, errors, completed=False):
     rate = processed / elapsed
     if completed:
         current_app.logger.info(
-            f"Exporter completed: processed {processed:_}/{total:_} records in "
-            f"{_format_duration(elapsed)} at {rate:,.1f} records/s with {errors:_} errors"
+            "Exporter completed: processed %s/%s records in %s at %s records/s "
+            "with %s errors",
+            f"{processed:_}",
+            f"{total:_}",
+            _format_duration(elapsed),
+            f"{rate:,.1f}",
+            f"{errors:_}",
         )
         return
 
     percentage = processed / total * 100 if total else 100
     remaining = max(total - processed, 0) / rate if rate else 0
     current_app.logger.info(
-        f"Processed {processed:_}/{total:_} records ({percentage:.1f}%) at "
-        f"{rate:,.1f} records/s; ETA {_format_duration(remaining)}; "
-        f"errors: {errors:_}"
+        "Processed %s/%s records (%.1f%%) at %s records/s; ETA %s; errors: %s",
+        f"{processed:_}",
+        f"{total:_}",
+        percentage,
+        f"{rate:,.1f}",
+        _format_duration(remaining),
+        f"{errors:_}",
     )
 
 
@@ -147,7 +156,7 @@ def _write_record(record, formats, archives, deleted_writer):
             ]
         except Exception:
             current_app.logger.exception(
-                f"Could not export deleted record: {record_id}"
+                "Could not export deleted record: %s", record_id
             )
             return 1
 
@@ -160,7 +169,7 @@ def _write_record(record, formats, archives, deleted_writer):
             content = SERIALIZERS[format](record)
         except Exception:
             current_app.logger.exception(
-                f"Could not serialize record {record_id} as {format}"
+                "Could not serialize record %s as %s", record_id, format
             )
             errors += 1
             continue

--- a/site/zenodo_rdm/exporter/writers.py
+++ b/site/zenodo_rdm/exporter/writers.py
@@ -89,31 +89,37 @@ def _write_record(record, formats, archives, deleted_writer):
         return
 
     if record.get("deletion_status", {}).get("is_deleted", False):
-        tombstone = record.get("tombstone", {})
-        removal_reason = tombstone.get("removal_reason", {}).get("id")
-        deleted_writer.writerow(
-            [
+        try:
+            tombstone = record.get("tombstone") or {}
+            removal_reason = (tombstone.get("removal_reason") or {}).get("id")
+            parent = record.get("parent") or {}
+            row = [
                 record_id,
                 record["pids"]["doi"]["identifier"],
-                record.get("parent", {}).get("id"),
-                record.get("parent", {})
-                .get("pids", {})
-                .get("doi", {})
-                .get("identifier"),
+                parent.get("id"),
+                (parent.get("pids") or {}).get("doi", {}).get("identifier"),
                 tombstone.get("note"),
                 removal_reason,
                 tombstone.get("removal_date"),
                 tombstone.get("citation_text") if removal_reason != "spam" else None,
             ]
-        )
+        except Exception:
+            current_app.logger.exception(
+                f"Could not export deleted record: {record_id}"
+            )
+            return
+
+        deleted_writer.writerow(row)
         return
 
     for format in formats:
         try:
             content = SERIALIZERS[format](record)
         except Exception:
-            current_app.logger.exception(f"Could not serialize record: {record_id}")
-            raise
+            current_app.logger.exception(
+                f"Could not serialize record {record_id} as {format}"
+            )
+            continue
 
         info = tarfile.TarInfo(f"{record_id}.{format}")
         info.size = len(content)


### PR DESCRIPTION
- **fix(exporter): continue after malformed records**
  * Preserve usable formats and subsequent records when one serialization fails.
  * Keep archive and storage failures fatal so incomplete output is not silently published.
  

- **feat(exporter): log progress and throughput**
  * Export runs can take hours, so operators need an accurate total, processing rate, and ETA rather than a debug-only record index.
  * The final summary exposes format-level errors without treating data-specific failures as a failed run.
  

- **fix(exporter): preserve Sentry error grouping**
  * Use lazy logging arguments so record-specific values do not split related failures into separate Sentry issues.
  