### PR TITLE
legacy: fix file delete endpoint

### DIFF
--- a/site/tests/legacy/test_quickstart.py
+++ b/site/tests/legacy/test_quickstart.py
@@ -121,6 +121,13 @@ def test_quickstart_workflow(
     assert data["delete_marker"] is False
     assert {"self", "uploads", "version"} <= data["links"].keys()
 
+    # Delete a file with /api/files
+    res = client.delete(
+        f"{bucket_url}/my_third_file.csv",
+        headers=headers,
+    )
+    assert res.status_code == 204
+
     # modify deposit
     deposit = {
         "metadata": {

--- a/site/zenodo_rdm/legacy/resources.py
+++ b/site/zenodo_rdm/legacy/resources.py
@@ -352,7 +352,6 @@ class LegacyFilesRESTResource(FileResource):
         return commit_file_result.to_dict(), 201
 
     @request_files_view_args
-    @response_handler()
     def delete_object(self):
         """Delete a file as in Files-REST views."""
         bucket_id = resource_requestctx.view_args["bucket_id"]


### PR DESCRIPTION
Deleting a file via `/api/files/{bucket_id}/{filename}` does delete the file, but returns an error 500 (Internal Server Error) to the legacy REST API users.

See [previous CI run with the failing added test](https://github.com/zenodo/zenodo-rdm/actions/runs/33155125403/job/98795971100):

```
self = <LegacyFilesRESTSchema(many=False)>, obj = ''

    def dump_links(self, obj):
        """Dump links with the prefix `files_rest.``."""
        return {
            k.split("files_rest.")[1]: v
>           for k, v in obj["links"].items()
                        ^^^^^^^^^^^^
            if k.startswith("files_rest.")
        }
E       TypeError: string indices must be integers, not 'str'

zenodo_rdm/legacy/serializers/schemas/files.py:48: TypeError
```

This is because the `delete_object` method returns an empty string, but we try to serialize it because of the `@response_handler()` annotation.