### PR TITLE
fix(legacy): fix broken bucket ID parsing

### DIFF
--- a/site/tests/legacy/conftest.py
+++ b/site/tests/legacy/conftest.py
@@ -4,7 +4,10 @@
 
 import pytest
 
-from zenodo_rdm.legacy.resources import LegacyRecordResourceConfig
+from zenodo_rdm.legacy.resources import (
+    LegacyFilesRESTResourceConfig,
+    LegacyRecordResourceConfig,
+)
 
 
 @pytest.fixture
@@ -12,3 +15,10 @@ def deposit_url(test_app):
     """Deposit API URL."""
     host = test_app.config["SITE_API_URL"]
     return f"{host}{LegacyRecordResourceConfig.url_prefix}"
+
+
+@pytest.fixture
+def files_rest_url(test_app):
+    """Files-REST API URL."""
+    host = test_app.config["SITE_API_URL"]
+    return f"{host}{LegacyFilesRESTResourceConfig.url_prefix}"

--- a/site/tests/legacy/test_files_operations.py
+++ b/site/tests/legacy/test_files_operations.py
@@ -7,6 +7,7 @@ and ``/api/files/<bucket_id>/<key>`` (Files-REST API).
 """
 
 from io import BytesIO
+from uuid import uuid4
 
 DEPOSIT_DATA = {
     "metadata": {
@@ -144,3 +145,12 @@ def test_files_rest_operations(client, deposit_url, headers, files_headers, uplo
     assert res.status_code == 404
     res = client.delete(f"{bucket_url}/data.txt", headers=headers)
     assert res.status_code == 404
+
+
+def test_files_rest_bad_bucket_id(client, files_rest_url):
+    """A bucket ID that isn't a known UUID is a 404, not a 500."""
+    for bucket_id in (uuid4(), "5840260"):
+        res = client.get(f"{files_rest_url}/{bucket_id}")
+        assert res.status_code == 404, res.text
+        res = client.get(f"{files_rest_url}/{bucket_id}/data.xlsx")
+        assert res.status_code == 404, res.text

--- a/site/zenodo_rdm/legacy/services.py
+++ b/site/zenodo_rdm/legacy/services.py
@@ -4,6 +4,7 @@
 
 from copy import deepcopy
 from os.path import splitext
+from uuid import UUID
 
 from flask import current_app
 from invenio_app_rdm.records_ui.previewer.iiif_simple import (
@@ -386,6 +387,13 @@ class LegacyFileService(FileService):
 
     def get_record_by_bucket_id(self, bucket_id):
         """Get the associated record by its bucket ID."""
+        try:
+            # Files-REST 404s on an unparseable bucket ID; without this the UUID
+            # column coercion raises instead.
+            bucket_id = UUID(bucket_id)
+        except ValueError:
+            raise NoResultFound()
+
         try:
             # Try first the draft
             model_cls = self.record_cls.model_cls


### PR DESCRIPTION
- **tests(legacy): replicate 500 on malformed Files-REST bucket ID**
  Old-style `/api/files/<recid>/<filename>` links pass a record ID where a
  bucket UUID is expected.
  

- **fix(legacy): 404 instead of 500 on malformed bucket ID**
  A non-UUID bucket ID reached the query, where the UUID column coercion raised
  `ValueError`. Files-REST 404s on a bucket ID it cannot parse, so match that;
  validating in the view args parser would give a 400 instead.
  