### PR TITLE
fix: prevent hyperlink injection in zenodo email

### DIFF
--- a/site/tests/test_email.py
+++ b/site/tests/test_email.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+
+import pytest
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "templates" / "security" / "email"
+
+@pytest.mark.parametrize(
+    "template_path",
+    sorted(TEMPLATES_DIR.glob("*.html")),
+    ids=lambda p: p.name,
+)
+def test_no_full_name_reference(template_path):
+    """Make sure we dont introduce `full_name` into any email we send"""
+    assert "full_name" not in template_path.read_text()

--- a/templates/security/email/change_notice.html
+++ b/templates/security/email/change_notice.html
@@ -8,9 +8,8 @@
             </td>
         </tr>
         <tr>
-            {% set name = user.profile.full_name if user.profile and user.profile.full_name else user.username %}
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
+                <p>{{ _('Hello, @%(username)s!', username=user.username) }}</p>
                 <p>{{ _('Your password has been successfully changed!') }}</p>
             </td>
         </tr>

--- a/templates/security/email/confirmation_instructions.html
+++ b/templates/security/email/confirmation_instructions.html
@@ -8,9 +8,8 @@
             </td>
         </tr>
         <tr>
-            {% set name = user.profile.full_name if user.profile and user.profile.full_name else user.username %}
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
+                <p>{{ _('Hello, @%(username)s!', username=user.username) }}</p>
                 <p>{{ _('You have received this message because your email address has been registered with Zenodo.') }} </p>
                 <p>{{ _('Verify yourself and confirm your email by clicking below.') }}</p>
             </td>

--- a/templates/security/email/reset_instructions.html
+++ b/templates/security/email/reset_instructions.html
@@ -8,9 +8,8 @@
             </td>
         </tr>
         <tr>
-            {% set name = user.profile.full_name if user.profile and user.profile.full_name else user.username %}
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
+                <p>{{ _('Hello, @%(username)s!', username=user.username) }}</p>
                 <p>{{ _('There was a request to reset your password.') }}</p>
                 <p>{{ _('If you did not make this request then please ignore this message.') }}</p>
                 <p>{{ _('Otherwise, please press the button below to change your password.') }}</p>

--- a/templates/security/email/reset_notice.html
+++ b/templates/security/email/reset_notice.html
@@ -8,9 +8,8 @@
             </td>
         </tr>
         <tr>
-            {% set name = user.profile.full_name if user.profile and user.profile.full_name else user.username %}
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
+                <p>{{ _('Hello, @%(username)s!', username=user.username) }}</p>
                 <p>{{ _('Your password has been successfully reset!') }}</p>
             </td>
         </tr>

--- a/templates/security/email/welcome.html
+++ b/templates/security/email/welcome.html
@@ -9,7 +9,7 @@
         </tr>
         <tr>
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Welcome %(username)s!', username= (user.user_profile.get('full_name') or user.username)) }}</p>
+                <p>{{ _('Welcome @%(username)s!', username=user.username) }}</p>
                 <p>{{ _('Your Zenodo account has been created.')}} </p>
                 <p>{{_('We are excited to have you get started!') }} </p>
             </td>


### PR DESCRIPTION
Closes: https://github.com/zenodo/ops/issues/537

* Full name allows characters like `.` in them making it possible to make a url your `full name`
* Removing the `full name` from the email prevents vulnerabilities.

