### PR TITLE
fix: emailing users without usernames

### DIFF
--- a/templates/security/email/change_notice.html
+++ b/templates/security/email/change_notice.html
@@ -9,7 +9,8 @@
         </tr>
         <tr>
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, @%(username)s!', username=user.username) }}</p>
+                {% set name = "@" ~ user.username if user.username is not none else "Zenodo user" %}
+                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
                 <p>{{ _('Your password has been successfully changed!') }}</p>
             </td>
         </tr>

--- a/templates/security/email/confirmation_instructions.html
+++ b/templates/security/email/confirmation_instructions.html
@@ -9,7 +9,8 @@
         </tr>
         <tr>
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, @%(username)s!', username=user.username) }}</p>
+                {% set name = "@" ~ user.username if user.username is not none else "Zenodo user" %}
+                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
                 <p>{{ _('You have received this message because your email address has been registered with Zenodo.') }} </p>
                 <p>{{ _('Verify yourself and confirm your email by clicking below.') }}</p>
             </td>

--- a/templates/security/email/reset_instructions.html
+++ b/templates/security/email/reset_instructions.html
@@ -9,7 +9,8 @@
         </tr>
         <tr>
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, @%(username)s!', username=user.username) }}</p>
+                {% set name = "@" ~ user.username if user.username is not none else "Zenodo user" %}
+                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
                 <p>{{ _('There was a request to reset your password.') }}</p>
                 <p>{{ _('If you did not make this request then please ignore this message.') }}</p>
                 <p>{{ _('Otherwise, please press the button below to change your password.') }}</p>

--- a/templates/security/email/reset_notice.html
+++ b/templates/security/email/reset_notice.html
@@ -9,7 +9,8 @@
         </tr>
         <tr>
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Hello, @%(username)s!', username=user.username) }}</p>
+                {% set name = "@" ~ user.username if user.username is not none else "Zenodo user" %}
+                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
                 <p>{{ _('Your password has been successfully reset!') }}</p>
             </td>
         </tr>

--- a/templates/security/email/welcome.html
+++ b/templates/security/email/welcome.html
@@ -9,7 +9,8 @@
         </tr>
         <tr>
             <td style="padding:5px 15px 10px 15px;">
-                <p>{{ _('Welcome @%(username)s!', username=user.username) }}</p>
+                {% set name = "@" ~ user.username if user.username is not none else "Zenodo user" %}
+                <p>{{ _('Hello, %(name)s!', name=name) }}</p>
                 <p>{{ _('Your Zenodo account has been created.')}} </p>
                 <p>{{_('We are excited to have you get started!') }} </p>
             </td>


### PR DESCRIPTION
* full name was removed from emails because of a vulnerability
* we replaced with username
* some accounts in Zenodo don't have username