### PR TITLE
Compare metadata workflow

### DIFF
--- a/scripts/ec_create_checks.py
+++ b/scripts/ec_create_checks.py
@@ -513,12 +513,18 @@ FUNDING_CHECK_CONFIG = {
     "funding_description": "The system compares the record title and description against the official EU grant description.",
 }
 
+COMPARE_METADATA_CHECK_CONFIG = {
+    "compare_metadata_title": "Record's metadata should match content of the uploaded file.",
+    "compare_metadata_description": "The system compares the record metadata against the uploaded file.",
+}
+
 
 def create_eu_checks():
     eu_comm = community_service.record_cls.pid.resolve("eu")
     create_metadata_checks(eu_comm)
     create_file_format_checks(eu_comm)
     create_funding_check(eu_comm)
+    create_compare_metadata_check(eu_comm)
     print("EU Open Research Repository community checks created/updated successfully.")
 
     # Create checks for sub-communities
@@ -674,6 +680,29 @@ def create_funding_check(comm):
         f"Funding check created/updated successfully for community {comm.slug}."
     )
 
+
+def create_compare_metadata_check(comm):
+    existing_check = CheckConfig.query.filter_by(
+        community_id=comm.id, check_id="compare_metadata"
+    ).one_or_none()
+    if existing_check:
+        existing_check.params = COMPARE_METADATA_CHECK_CONFIG
+        existing_check.target_type = "record"
+    else:
+        db.session.add(
+            CheckConfig(
+                community_id=comm.id,
+                check_id="compare_metadata",
+                params=COMPARE_METADATA_CHECK_CONFIG,
+                target_type="record",
+                severity=Severity.WARN,
+                enabled=True,
+            )
+        )
+    db.session.commit()
+    print(
+        f"Metadata Comparison check created/updated successfully for community {comm.slug}."
+    )
 
 if __name__ == "__main__":
     create_eu_checks()

--- a/site/pyproject.toml
+++ b/site/pyproject.toml
@@ -22,6 +22,7 @@ zenodo_rdm_stats = "zenodo_rdm.stats.ext:ZenodoStats"
 zenodo_rdm_curation = "zenodo_rdm.curation.ext:ZenodoCuration"
 zenodo_rdm_exporter = "zenodo_rdm.exporter.ext:ZenodoExporter"
 zenodo_rdm_theme = "zenodo_rdm.theme.ext:ZenodoTheme"
+zenodo_rdm_checks = "zenodo_rdm.checks.ext:ZenodoChecks"
 
 [project.entry-points."invenio_base.api_apps"]
 zenodo_rdm_legacy = "zenodo_rdm.legacy.ext:ZenodoLegacy"
@@ -92,6 +93,7 @@ subcommunity_member = "zenodo_rdm.subcommunities.checks:CommunityMembershipCheck
 subcommunity_validation = "zenodo_rdm.subcommunities.checks:SubcommunityValidationCheck"
 subcommunity_record_metadata = "zenodo_rdm.subcommunities.checks:SubcommunityRecordCheck"
 funding = "zenodo_rdm.checks.funding:FundingCheck"
+compare_metadata = "zenodo_rdm.checks.compare_metadata:MetadataComparisonCheck"
 
 [project.entry-points."invenio_jobs.jobs"]
 eu_records_curation = "zenodo_rdm.curation.jobs:EURecordCuration"

--- a/site/zenodo_rdm/checks/checks_diff.py
+++ b/site/zenodo_rdm/checks/checks_diff.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+#
+# Zenodo RDM is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+"""Formatting and displaying checks with diffs."""
+
+import difflib
+import itertools
+
+from invenio_i18n import gettext as _
+from markupsafe import Markup, escape
+
+
+def _diff(current, suggested, join_fn):
+    """Diff two sequences; join(slice) turns sequence back into escaped HTML."""
+    matcher = difflib.SequenceMatcher(None, current, suggested)
+    current_parts, suggested_parts = [], []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            chunk = join_fn(current[i1:i2])
+            current_parts.append(chunk)
+            suggested_parts.append(chunk)
+            continue
+        if i1 != i2:
+            current_parts.append(f'<del class="diff-removed">{join_fn(current[i1:i2])}</del>')
+        if j1 != j2:
+            suggested_parts.append(f'<ins class="diff-added">{join_fn(suggested[j1:j2])}</ins>')
+    return current_parts, suggested_parts
+
+def _diff_words(current_text, suggested_text):
+    """Word-level diff of two strings.
+
+    Returns (current_html, suggested_html) with only the words that changed
+    wrapped in `<del>`/`<ins>`, so unchanged words render plainly.
+    """
+    def join_fn(sequence):
+        return " ".join(str(escape(w)) for w in sequence)
+
+    current_words = (current_text or "").split()
+    suggested_words = (suggested_text or "").split()
+
+    current_parts, suggested_parts = _diff(current_words, suggested_words, join_fn)
+    return " ".join(current_parts), " ".join(suggested_parts)
+
+
+def _diff_chars(current_text, suggested_text):
+    """Character-level diff of two strings.
+
+    Same shape as `_diff_words`, but for identifiers like DOIs where a
+    single changed character shouldn't highlight the whole value.
+    """
+    def join_fn(sequence):
+        return str(escape(sequence))
+
+    current_text = current_text or ""
+    suggested_text = suggested_text or ""
+
+    current_parts, suggested_parts = _diff(current_text, suggested_text, join_fn)
+    return "".join(current_parts), "".join(suggested_parts)
+
+
+def _diff_mapping_item(current, suggested):
+    """Diff two comparable dicts key-by-key."""
+    current = current or {}
+    suggested = suggested or {}
+
+    current_parts = []
+    suggested_parts = []
+    for key in dict.fromkeys([*current.keys(), *suggested.keys()]):
+        c_val = str(current.get(key, ""))
+        s_val = str(suggested.get(key, ""))
+        if not c_val and not s_val:
+            continue
+        c_html, s_html = _diff_words(c_val, s_val)
+        if c_val:
+            current_parts.append(c_html)
+        if s_val:
+            suggested_parts.append(s_html)
+
+    return ", ".join(current_parts), ", ".join(suggested_parts)
+
+
+def _diff_funding_item(current, suggested):
+    """Diff two funding entries, with 'Award: X (Y), Funder: Z' shape."""
+    def build(item, title_html, number_html, funder_html):
+        parts = []
+        title = item.get("award_title")
+        number = item.get("award_number")
+        if title and number:
+            parts.append(
+                _(
+                    "Award: %(title)s (%(number)s)",
+                    title=Markup(title_html),
+                    number=Markup(number_html),
+                )
+            )
+        elif title:
+            parts.append(_("Award: %(title)s", title=Markup(title_html)))
+        elif number:
+            parts.append(_("Award: %(number)s", number=Markup(number_html)))
+
+        if item.get("funder_name") or item.get("funder_id"):
+            parts.append(_("Funder: %(funder)s", funder=Markup(funder_html)))
+
+        return ", ".join(str(p) for p in parts)
+
+    current = current or {}
+    suggested = suggested or {}
+
+    c_title_html, s_title_html = _diff_words(
+        current.get("award_title", ""),
+        suggested.get("award_title", ""),
+    )
+    c_number_html, s_number_html = _diff_chars(
+        current.get("award_number", ""), suggested.get("award_number", "")
+    )
+    c_funder_html, s_funder_html = _diff_words(
+        current.get("funder_name") or current.get("funder_id", ""),
+        suggested.get("funder_name") or suggested.get("funder_id", ""),
+    )
+
+    current_html = build(current, c_title_html, c_number_html, c_funder_html)
+    suggested_html = build(suggested, s_title_html, s_number_html, s_funder_html)
+    return current_html, suggested_html
+
+
+def diff_comparison(comparison):
+    """Diff-highlight a metadata comparison entry.
+
+    Returns (current_html, suggested_html) Markup, highlighting
+    only what changed.
+    """
+    field = comparison.get("field")
+    current = comparison.get("current")
+    suggested = comparison.get("suggested")
+
+    if isinstance(current, list) or isinstance(suggested, list):
+        diff_fn = _diff_funding_item if field == "funding" else _diff_mapping_item
+        current_items = []
+        suggested_items = []
+        for c_item, s_item in itertools.zip_longest(current or [], suggested or []):
+            c_html, s_html = diff_fn(c_item, s_item)
+            if c_html:
+                current_items.append(f"<li>{c_html}</li>")
+            if s_html:
+                suggested_items.append(f"<li>{s_html}</li>")
+        current_html = (
+            f'<ul class="rel-ml-1">{"".join(current_items)}</ul>'
+            if current_items
+            else "—"
+        )
+        suggested_html = (
+            f'<ul class="rel-ml-1">{"".join(suggested_items)}</ul>'
+            if suggested_items
+            else "—"
+        )
+    else:
+        diff_fn = _diff_chars if field == "doi" else _diff_words
+        current_html, suggested_html = diff_fn(current or "", suggested or "")
+        current_html = current_html or "—"
+        suggested_html = suggested_html or "—"
+
+    return Markup(current_html), Markup(suggested_html)

--- a/site/zenodo_rdm/checks/compare_metadata.py
+++ b/site/zenodo_rdm/checks/compare_metadata.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+#
+# Zenodo RDM is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+"""Metadata comparison check using orcha."""
+
+import hashlib
+import html
+import json
+from dataclasses import dataclass, field
+
+import bleach
+import requests
+from flask import current_app
+from flask_babel import gettext as _
+from invenio_checks.base import Check, CheckResult
+from invenio_checks.models import CheckConfig
+from invenio_checks.utils import translate_field
+
+from zenodo_rdm.orcha.utils import run_compare_metadata_workflow
+
+
+def format_funding_item(item):
+    """Format a funding comparison entry, e.g. 'Award: X (Y), Funder: Z'."""
+    if not item:
+        return ""
+
+    parts = []
+
+    title = translate_field(item.get("award_title"))
+    number = item.get("award_number")
+
+    if title and number:
+        parts.append(_("Award: %(title)s (%(number)s)", title=title, number=number))
+    elif title:
+        parts.append(_("Award: %(title)s", title=title))
+    elif number:
+        parts.append(_("Award: %(number)s", number=number))
+
+    funder = item.get("funder_name") or item.get("funder_id")
+    if funder:
+        parts.append(_("Funder: %(funder)s", funder=funder))
+
+    return ", ".join(parts)
+
+
+@dataclass
+class ComparisonCheckResult(CheckResult):
+    """CheckResult with additional fields for comparison checks."""
+    describes_file: bool = False
+    comparisons: list[dict] = field(default_factory=list)
+
+
+class MetadataComparisonCheck(Check):
+    """Check whether a record's metadata accurately describes its uploaded file."""
+
+    id = "compare_metadata"
+    title = "Metadata comparison check"
+    description = (
+        "Compares the record's metadata against the content of the uploaded file."
+    )
+    sort_order = 35
+    sync = False
+    target_type = "record"
+
+    default_messages = {
+        "title": "Record's metadata should match content of the uploaded file.",
+        "description": "The system compares the record metadata against the uploaded file.",
+    }
+
+    def _get_file_checksum(self, record):
+        """Return the checksum of the single uploaded file, or None."""
+        files = record.files
+        if not files or not files.entries:
+            return None
+        file_keys = list(files.entries.keys())
+        if len(file_keys) != 1:
+            return None
+        ov = record.files[file_keys[0]].object_version
+        if not ov:
+            return None
+        return ov.file.checksum if ov.file else None
+
+    def _get_input_hash(self, record):
+        """Return a hash of the inputs used to detect when the check needs to rerun."""
+        input_data = {
+            **self._extract_metadata(record),
+            "file_checksum": self._get_file_checksum(record),
+        }
+        return hashlib.sha256(
+            json.dumps(input_data, sort_keys=True, default=str).encode()
+        ).hexdigest()
+
+    def should_rerun(self, record, config, previous_run, **kwargs):
+        """Return True if metadata fields or the uploaded file changed since the last run."""
+        return previous_run.state.get("input_hash") != self._get_input_hash(record)
+
+    def _strip_html(self, value):
+        """Convert rich-text HTML (e.g. a description) to plain text."""
+        text = bleach.clean(value, tags=[], attributes=[], strip=True)
+        return " ".join(html.unescape(text).split())
+
+    def _extract_metadata(self, record):
+        """Extract a flat metadata dict from the record for the comparison workflow."""
+        metadata = record.get("metadata", {})
+        pids = record.get("pids", {})
+
+        creators = []
+        for c in metadata.get("creators", []):
+            p = c.get("person_or_org", {})
+            family = p.get("family_name", "")
+            given = p.get("given_name", "")
+            name = f"{family}, {given}".strip(", ") if given else family
+            orcid = next(
+                (
+                    i["identifier"]
+                    for i in p.get("identifiers", [])
+                    if i.get("scheme") == "orcid"
+                ),
+                None,
+            )
+            affiliations = c.get("affiliations") or []
+            affiliation = affiliations[0].get("name") if affiliations else None
+            creators.append({"name": name, "orcid": orcid, "affiliation": affiliation})
+
+        licenses = []
+        for right in metadata.get("rights", []):
+            entry = {"id": right.get("id", "")}
+            if right_title := right.get("title"):
+                entry["title"] = right_title.get("en", "")
+            licenses.append(entry)
+
+        return {
+            "title": metadata.get("title", ""),
+            "description": self._strip_html(metadata.get("description", "")),
+            "creators": creators,
+            "publication_date": metadata.get("publication_date", ""),
+            "doi": pids.get("doi", {}).get("identifier", ""),
+            "license": licenses,
+            "copyright": metadata.get("copyright", ""),
+            "funding": metadata.get("funding", []),
+        }
+
+    def run(self, record, config: CheckConfig, **kwargs):
+        """Run the metadata comparison check."""
+
+        def get_updated_result(check_result, message, success):
+            check_result.success = success
+            check_result.description = message
+            if not success:
+                check_result.errors.append(
+                    {
+                        "messages": [message],
+                        "description": description,
+                        "severity": config.severity.error_value,
+                    }
+                )
+            return check_result
+
+        params = config.params
+        description = params.get(
+            "compare_metadata_description",
+            self.default_messages["description"],
+        )
+        check_result = ComparisonCheckResult(
+            id=self.id,
+            title=params.get("compare_metadata_title", self.default_messages["title"]),
+            description=description,
+        )
+
+        files = record.files
+        if not files or not files.entries:
+            check_result.success = False
+            check_result.description = "Record has no files to compare against."
+            return check_result, {}
+
+        file_keys = list(files.entries.keys())
+        if len(file_keys) > 1:
+            msg = "Metadata check only supports records with a single file."
+            return get_updated_result(check_result, msg, False), {}
+
+        file_key = file_keys[0]
+        if not (files.mimetypes[0] == "application/pdf" and file_key.endswith(".pdf")):
+            msg = "Metadata check only supports PDF files."
+            return get_updated_result(check_result, msg, False), {}
+
+        pid_value = record.pid.pid_value
+        current_metadata = self._extract_metadata(record)
+
+        try:
+            status, result = run_compare_metadata_workflow(
+                pid_value, file_key, current_metadata
+            )
+        except (RuntimeError, requests.ConnectionError, requests.HTTPError):
+            msg = "Metadata comparison service unavailable."
+            return get_updated_result(check_result, msg, False), {}
+        except requests.Timeout:
+            msg = "Metadata comparison service timed out, please try again."
+            return get_updated_result(check_result, msg, False), {}
+        except Exception:
+            current_app.logger.exception(
+                "Unexpected error running metadata comparison workflow"
+            )
+            msg = "Metadata comparison service unavailable."
+            return get_updated_result(check_result, msg, False), {}
+
+        if status == "error":
+            msg = "Error running the metadata comparison check. Please try again later."
+            return get_updated_result(check_result, msg, False), {}
+        if status == "timeout":
+            msg = "Metadata comparison service timed out, please try again."
+            return get_updated_result(check_result, msg, False)
+
+        describes_file = result.get("describes_file")
+        decision = result.get("decision", "")
+        comparisons = result.get("comparisons", [])
+
+        check_result.success = bool(describes_file)
+        check_result.description = decision
+
+        if not describes_file:
+            check_result.add_errors(
+                [
+                    {
+                        "field": "metadata",
+                        "messages": [decision],
+                        "description": decision,
+                        "severity": config.severity.error_value,
+                    }
+                ]
+            )
+
+        check_result.describes_file = describes_file
+        check_result.comparisons = comparisons
+        return check_result, {
+            "workflow_id": result.get("workflow_id"),
+            "input_hash": self._get_input_hash(record),
+        }

--- a/site/zenodo_rdm/checks/compare_metadata.py
+++ b/site/zenodo_rdm/checks/compare_metadata.py
@@ -13,37 +13,10 @@ from dataclasses import dataclass, field
 
 import bleach
 import requests
-from flask import current_app
-from flask_babel import gettext as _
 from invenio_checks.base import Check, CheckResult
 from invenio_checks.models import CheckConfig
-from invenio_checks.utils import translate_field
 
 from zenodo_rdm.orcha.utils import run_compare_metadata_workflow
-
-
-def format_funding_item(item):
-    """Format a funding comparison entry, e.g. 'Award: X (Y), Funder: Z'."""
-    if not item:
-        return ""
-
-    parts = []
-
-    title = translate_field(item.get("award_title"))
-    number = item.get("award_number")
-
-    if title and number:
-        parts.append(_("Award: %(title)s (%(number)s)", title=title, number=number))
-    elif title:
-        parts.append(_("Award: %(title)s", title=title))
-    elif number:
-        parts.append(_("Award: %(number)s", number=number))
-
-    funder = item.get("funder_name") or item.get("funder_id")
-    if funder:
-        parts.append(_("Funder: %(funder)s", funder=funder))
-
-    return ", ".join(parts)
 
 
 @dataclass
@@ -199,19 +172,13 @@ class MetadataComparisonCheck(Check):
         except requests.Timeout:
             msg = "Metadata comparison service timed out, please try again."
             return get_updated_result(check_result, msg, False), {}
-        except Exception:
-            current_app.logger.exception(
-                "Unexpected error running metadata comparison workflow"
-            )
-            msg = "Metadata comparison service unavailable."
-            return get_updated_result(check_result, msg, False), {}
 
         if status == "error":
             msg = "Error running the metadata comparison check. Please try again later."
             return get_updated_result(check_result, msg, False), {}
         if status == "timeout":
             msg = "Metadata comparison service timed out, please try again."
-            return get_updated_result(check_result, msg, False)
+            return get_updated_result(check_result, msg, False), {}
 
         describes_file = result.get("describes_file")
         decision = result.get("decision", "")

--- a/site/zenodo_rdm/checks/ext.py
+++ b/site/zenodo_rdm/checks/ext.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""ZenodoRDM Checks module."""
+
+from zenodo_rdm.checks.compare_metadata import format_funding_item
+
+
+class ZenodoChecks:
+    """Zenodo Checks extension."""
+
+    def __init__(self, app=None):
+        """Extension initialization."""
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Flask application initialization."""
+        app.extensions["zenodo-checks"] = self
+        app.jinja_env.filters["format_funding_item"] = format_funding_item

--- a/site/zenodo_rdm/checks/ext.py
+++ b/site/zenodo_rdm/checks/ext.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """ZenodoRDM Checks module."""
 
-from zenodo_rdm.checks.compare_metadata import format_funding_item
+from zenodo_rdm.checks.checks_diff import diff_comparison
 
 
 class ZenodoChecks:
@@ -16,4 +16,4 @@ class ZenodoChecks:
     def init_app(self, app):
         """Flask application initialization."""
         app.extensions["zenodo-checks"] = self
-        app.jinja_env.filters["format_funding_item"] = format_funding_item
+        app.jinja_env.filters["diff_comparison"] = diff_comparison

--- a/site/zenodo_rdm/orcha/utils.py
+++ b/site/zenodo_rdm/orcha/utils.py
@@ -100,3 +100,21 @@ def run_funding_relevance_workflow(metadata, award_description, rule=""):
     # poll for result using a scoped token, until done
     _status, result = _poll_to_return_result(client, workflow_id)
     return result
+
+
+def run_compare_metadata_workflow(pid_value, file_key, metadata):
+    """Run the compare_metadata LLM workflow, returning the result dict or {} on timeout."""
+    client, token = _get_orcha_client_token()
+    file_url = _file_download_url(
+        pid_value, client, key=file_key, identity=system_identity
+    )
+    payload = {
+        "workflow_type": "compare_metadata",
+        "params": {
+            "url": file_url,
+            "metadata": metadata,
+        },
+    }
+    response = _trigger_workflow(client, token, payload)
+    workflow_id = response["public_id"]
+    return _poll_to_return_result(client, workflow_id, poll_until=40)

--- a/site/zenodo_rdm/orcha/utils.py
+++ b/site/zenodo_rdm/orcha/utils.py
@@ -1,9 +1,17 @@
 # SPDX-FileCopyrightText: 2026 CERN
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Orcha related helpers."""
+
 import time
 
-from invenio_app_rdm.orcha.views import _orcha_client, _workflow_token
+import requests
+from flask import current_app
+from invenio_access.permissions import system_identity
+from invenio_app_rdm.orcha.views import (
+    _file_download_url,
+    _orcha_client,
+    _workflow_token,
+)
 
 FUNDING_CHECK_INSTRUCTIONS = """
     Given a record's title and description, and an EU grant's official description,
@@ -17,30 +25,78 @@ FUNDING_CHECK_INSTRUCTIONS = """
     - message: a one-sentence explanation of your decision
 """
 
-def run_funding_relevance_workflow(metadata, award_description, rule=""):
-    """Run the funding relevance LLM workflow, returning the result dict or {} on timeout."""
-    client = _orcha_client()
-    token = _workflow_token(client)
-    response = client.trigger_workflow(
-        payload={
-            "workflow_type": "check_funding_relevance",
-            "params": {
-                "metadata": metadata,
-                "award_description": award_description,
-                "rule": rule or FUNDING_CHECK_INSTRUCTIONS,
-            },
-        },
-        token=token,
-    )
-    workflow_id = response["public_id"]
-    # poll for result using a scoped token
+
+def _get_orcha_client_token():
+    try:
+        client = _orcha_client()
+        token = _workflow_token(client)
+        return client, token
+    except RuntimeError as e:
+        current_app.logger.error("Orcha misconfiguration: %s", e)
+        raise
+
+
+def _trigger_workflow(client, token, payload):
+    try:
+        response = client.trigger_workflow(
+            payload=payload,
+            token=token,
+        )
+        return response
+    except requests.ConnectionError:
+        current_app.logger.error("Cannot reach Orcha at %s", client.base_url)
+        raise
+    except requests.Timeout:
+        current_app.logger.error(
+            "Orcha request timed out (base_url=%s)", client.base_url
+        )
+        raise
+    except requests.HTTPError as e:
+        status = (
+            e.response.status_code
+            if e.response is not None
+            else "(missing status code)"
+        )
+        body = e.response.text if e.response is not None else ""
+        if status in (401, 403):
+            current_app.logger.error(
+                "Orcha auth failure (HTTP %s), check tenant config",
+                status,
+            )
+        elif status in (400, 422):
+            current_app.logger.error(
+                "Orcha rejected check payload (HTTP %s): %s", status, body
+            )
+        else:
+            current_app.logger.error("Orcha failed HTTP %s: %s", status, body)
+        raise
+
+
+def _poll_to_return_result(client, workflow_id, poll_until=20, sleep_time=3):
     workflow_token = _workflow_token(client, workflow_id)
-    # Poll until done
-    for _ in range(20):
-        time.sleep(3)
+    for _ in range(poll_until):
+        time.sleep(sleep_time)
         data = client.get_workflow(workflow_id, workflow_token)
         if data["status"] in ("success", "error"):
             result = data.get("result") or {}
             result["workflow_id"] = workflow_id
-            return result
-    return {}
+            return data["status"], result
+    return "timeout", {}
+
+
+def run_funding_relevance_workflow(metadata, award_description, rule=""):
+    """Run the funding relevance LLM workflow, returning the result dict or {} on timeout."""
+    client, token = _get_orcha_client_token()
+    payload = {
+        "workflow_type": "check_funding_relevance",
+        "params": {
+            "metadata": metadata,
+            "award_description": award_description,
+            "rule": rule or FUNDING_CHECK_INSTRUCTIONS,
+        },
+    }
+    response = _trigger_workflow(client, token, payload)
+    workflow_id = response["public_id"]
+    # poll for result using a scoped token, until done
+    _status, result = _poll_to_return_result(client, workflow_id)
+    return result

--- a/templates/semantic-ui/invenio_checks/requests/compare_metadata_tab.html
+++ b/templates/semantic-ui/invenio_checks/requests/compare_metadata_tab.html
@@ -15,31 +15,10 @@
   "funding": _("Funding"),
 } %}
 
-{% macro render_value(value, field=none) %}
-  {%- if value is none or value == "" -%}
-    —
-  {%- elif value is mapping -%}
-    {{ value.values() | select | join(", ") }}
-  {%- elif value is iterable and value is not string -%}
-    <ul class="rel-ml-1">
-      {% for item in value %}
-        {%- if item -%}
-          <li>
-            {%- if field == "funding" -%}
-              {{ item | format_funding_item }}
-            {%- elif item is mapping -%}
-              {{ item.values() | select | join(", ") }}
-            {%- else -%}
-              {{ item }}
-            {%- endif -%}
-          </li>
-        {%- endif -%}
-      {% endfor %}
-    </ul>
-  {%- else -%}
-    {{ value }}
-  {%- endif -%}
-{% endmacro %}
+<style>
+  .diff-removed { color: #9f3a38; background: #fff6f6; text-decoration: none; }
+  .diff-added { color: #1a7734; background: #fcfff5; text-decoration: none; }
+</style>
 
 <div class="ui column stackable grid">
   <div class="ten wide column">
@@ -69,47 +48,42 @@
             {% elif status == "ERROR" %}
                 <p>Could not complete this check within the maximum number of retries.</p>
             {% else %}
-                <p>{{ check.result.description }}</p>
-                {% set describes_file = check.result.describes_file %}
-                {% set message = check.result.message %}
-                {% set comparisons = check.result.comparisons %}
+              <p>{{ check.result.description }}</p>
 
-
-                {% if comparisons %}
-                  {% for comparison in comparisons %}
-                    {% set field = comparison.field %}
-                    {% set label = field_labels.get(field, field) %}
-                    <div class="ui divider"></div>
-                    <div class="ui grid rel-mb-2">
-                      <div class="row">
-                        <div class="sixteen wide column">
-                          <strong>{{ label }}</strong>
-                        </div>
-                      </div>
-                      <div class="row">
-                        <div class="eight wide column">
-                          <p class="text-muted"><small>{{ _("Current") }}</small></p>
-                          {{ render_value(comparison.current, field) }}
-                        </div>
-                        <div class="eight wide column">
-                          <p class="text-muted"><small>{{ _("Suggested") }}</small></p>
-                          {{ render_value(comparison.suggested, field) }}
-                        </div>
-                      </div>
-                      <div class="row">
-                        <div class="sixteen wide column">
-                          <p>{{ comparison.rationale }}</p>
-                        </div>
-                      </div>
+              {% for comparison in check.result.comparisons %}
+                {% set field = comparison.field %}
+                {% set label = field_labels.get(field, field) %}
+                {% set current_html, suggested_html = comparison | diff_comparison %}
+                <div class="ui divider"></div>
+                <div class="ui grid rel-mb-2">
+                  <div class="row">
+                    <div class="sixteen wide column">
+                      <strong>{{ label }}</strong>
                     </div>
+                  </div>
+                  <div class="row">
+                    <div class="eight wide column">
+                      <p class="text-muted"><small>{{ _("Current") }}</small></p>
+                      {{ current_html }}
+                    </div>
+                    <div class="eight wide column">
+                      <p class="text-muted"><small>{{ _("Suggested") }}</small></p>
+                      {{ suggested_html }}
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="sixteen wide column">
+                      <p>{{ comparison.rationale }}</p>
+                    </div>
+                  </div>
+                </div>
+              {% endfor %}
 
-                  {% endfor %}
-                {% endif %}
             {% endif %}
           </div>
-
         </div>
       </div>
+
     {% endfor %}
     </div>
   </div>

--- a/templates/semantic-ui/invenio_checks/requests/compare_metadata_tab.html
+++ b/templates/semantic-ui/invenio_checks/requests/compare_metadata_tab.html
@@ -1,0 +1,120 @@
+{# -*- coding: utf-8 -*-
+    Copyright (C) 2026 CERN.
+#}
+
+{% import "invenio_checks/requests/severity_level_icons.html" as severity_tpl %}
+
+{% set field_labels = {
+  "title": _("Title"),
+  "description": _("Description"),
+  "creators": _("Authors/Creators"),
+  "doi": _("DOI"),
+  "publication_date": _("Publication date"),
+  "license": _("License"),
+  "copyright": _("Copyright"),
+  "funding": _("Funding"),
+} %}
+
+{% macro render_value(value, field=none) %}
+  {%- if value is none or value == "" -%}
+    —
+  {%- elif value is mapping -%}
+    {{ value.values() | select | join(", ") }}
+  {%- elif value is iterable and value is not string -%}
+    <ul class="rel-ml-1">
+      {% for item in value %}
+        {%- if item -%}
+          <li>
+            {%- if field == "funding" -%}
+              {{ item | format_funding_item }}
+            {%- elif item is mapping -%}
+              {{ item.values() | select | join(", ") }}
+            {%- else -%}
+              {{ item }}
+            {%- endif -%}
+          </li>
+        {%- endif -%}
+      {% endfor %}
+    </ul>
+  {%- else -%}
+    {{ value }}
+  {%- endif -%}
+{% endmacro %}
+
+<div class="ui column stackable grid">
+  <div class="ten wide column">
+    <div class="ui very relaxed list rel-pl-2">
+    {% for check in checks %}
+      {% set status = check.status.name %}
+      {% set running = status == "PENDING" or status == "RUNNING" %}
+      {% set has_errors = not check.result.success or status == "ERROR" %}
+      {% set icon = (
+          severity_tpl.severity_level_icons["running"] if running else
+          severity_tpl.severity_level_icons["warning"] if has_errors else
+          severity_tpl.severity_level_icons["success"]
+        ) %}
+
+      <div class="item">
+        <div class="content">
+          <div class="header">
+            <i class="{{ icon }}"></i>
+            {{ check.result.title }}
+          </div>
+          <div class="text-muted">
+            <p><i class="rel-p-1 fire blue icon"></i>AI-assisted grant matching</p>
+          </div>
+          <div class="pt-5 text-muted">
+            {% if running %}
+                <p>Analysis in progress, please check back shortly.</p>
+            {% elif status == "ERROR" %}
+                <p>Could not complete this check within the maximum number of retries.</p>
+            {% else %}
+                <p>{{ check.result.description }}</p>
+                {% set describes_file = check.result.describes_file %}
+                {% set message = check.result.message %}
+                {% set comparisons = check.result.comparisons %}
+
+
+                {% if comparisons %}
+                  {% for comparison in comparisons %}
+                    {% set field = comparison.field %}
+                    {% set label = field_labels.get(field, field) %}
+                    <div class="ui divider"></div>
+                    <div class="ui grid rel-mb-2">
+                      <div class="row">
+                        <div class="sixteen wide column">
+                          <strong>{{ label }}</strong>
+                        </div>
+                      </div>
+                      <div class="row">
+                        <div class="eight wide column">
+                          <p class="text-muted"><small>{{ _("Current") }}</small></p>
+                          {{ render_value(comparison.current, field) }}
+                        </div>
+                        <div class="eight wide column">
+                          <p class="text-muted"><small>{{ _("Suggested") }}</small></p>
+                          {{ render_value(comparison.suggested, field) }}
+                        </div>
+                      </div>
+                      <div class="row">
+                        <div class="sixteen wide column">
+                          <p>{{ comparison.rationale }}</p>
+                        </div>
+                      </div>
+                    </div>
+
+                  {% endfor %}
+                {% endif %}
+            {% endif %}
+          </div>
+
+        </div>
+      </div>
+    {% endfor %}
+    </div>
+  </div>
+
+  <div class="six wide column">
+    {% include 'invenio_checks/requests/help_message.html' %}
+  </div>
+</div>


### PR DESCRIPTION
- **feat(checks): add highlighted diffs for checks**
Show current vs suggested metadata comparisons with only the changed words or characters highlighted inline. This helps users to quickly spot the differences between the two sets of fields.
- **feat(checks): add compare metadata check**
Add check to compare the record's metadata against the content of its uploaded PDF file via an Orcha LLM workflow. Display per-field comparisons, showing the current values vs the suggested values in the request checks tab.
- **refactor(orcha): improve error handling in utils**